### PR TITLE
feature: add serialization groups for frontend decks

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -3,8 +3,9 @@ api_platform:
     version: 1.0.0
     use_symfony_listeners: true
     formats:
+        json: [ 'application/json' ]
         jsonld: [ 'application/ld+json' ]
     defaults:
         stateless: true
         cache_headers:
-            vary: ['Content-Type', 'Authorization', 'Origin']
+            vary: [ 'Content-Type', 'Authorization', 'Origin' ]

--- a/migrations/Version20250708180752.php
+++ b/migrations/Version20250708180752.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250708180752 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX card_block_idx_content_type');
+        $this->addSql('ALTER TABLE card_block DROP content_type');
+        $this->addSql('ALTER TABLE card_block ALTER content TYPE TEXT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE card_block ADD content_type VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE card_block ALTER content TYPE JSONB');
+        $this->addSql('CREATE INDEX card_block_idx_content_type ON card_block (content_type)');
+    }
+}

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: CardRepository::class)]
 #[ORM\Index(name: 'card_idx_deck_position', columns: ['deck_id', 'position'])]
@@ -25,6 +26,7 @@ class Card
     private ?Deck $deck = null;
 
     #[ORM\Column(type: Types::SMALLINT)]
+    #[Groups(['deck:item'])]
     private ?int $position = 0;
 
     /**
@@ -32,6 +34,7 @@ class Card
      */
     #[ORM\OneToMany(targetEntity: CardSide::class, mappedBy: 'card', cascade: ['persist'], orphanRemoval: true)]
     #[ApiProperty(writableLink: true)]
+    #[Groups(['deck:item'])]
     private Collection $cardSides;
 
     public function __construct()

--- a/src/Entity/CardBlock.php
+++ b/src/Entity/CardBlock.php
@@ -7,6 +7,7 @@ use App\Entity\Traits\UuidTrait;
 use App\Repository\CardBlockRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: CardBlockRepository::class)]
 #[ORM\Index(name: 'card_block_idx_content', columns: ['content'])]
@@ -20,7 +21,8 @@ class CardBlock
     private ?CardSide $card_side = null;
 
     #[ORM\Column(type: Types::TEXT)]
-    private string $content;
+    #[Groups(['deck:item'])]
+    private ?string $content;
 
     public function getCardSide(): ?CardSide
     {

--- a/src/Entity/CardSide.php
+++ b/src/Entity/CardSide.php
@@ -8,6 +8,7 @@ use App\Entity\Traits\UuidTrait;
 use App\Enum\CardSides;
 use App\Repository\CardSideRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: CardSideRepository::class)]
 #[ORM\Index(name: 'card_side_idx_card_side', columns: ['card_id', 'side'])]
@@ -21,10 +22,12 @@ class CardSide
     private ?Card $card = null;
 
     #[ORM\Column(enumType: self::class)]
+    #[Groups(['deck:item'])]
     private ?CardSides $side = CardSides::FRONT;
 
     #[ORM\OneToOne(mappedBy: 'card_side', cascade: ['persist', 'remove'])]
     #[ApiProperty(writableLink: true)]
+    #[Groups(['deck:item'])]
     private ?CardBlock $cardBlock = null;
 
     public function getCard(): ?Card

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -19,15 +19,17 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: DeckRepository::class)]
 #[ORM\Index(name: 'deck_idx_visibility_status', columns: ['visibility', 'status'])]
 #[ORM\Index(name: 'deck_idx_rating_avg_count', columns: ['rating_avg', 'rating_count'])]
 #[ApiResource(
     operations: [
-        new Get(),
-        new GetCollection(),
+        new Get(normalizationContext: ['groups' => ['deck:read', 'deck:item', 'uuid']]),
+        new GetCollection(normalizationContext: ['groups' => ['deck:read']]),
         new Post(
+            normalizationContext: ['groups' => ['deck:read', 'deck:item', 'uuid']],
             security: "is_fully_authenticated()",
             securityMessage: "Only authenticated users can create decks",
         ),
@@ -41,36 +43,46 @@ class Deck
     use DateAtTrait;
 
     #[ORM\ManyToOne(inversedBy: 'decks')]
+    #[Groups(['deck:item'])]
     private ?User $owner = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(['deck:read', 'deck:item'])]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
+    #[Groups(['deck:read', 'deck:item'])]
     private ?string $description = null;
 
     #[ORM\Column(nullable: true, enumType: CountryCodeAlpha2::class)]
+    #[Groups(['deck:read', 'deck:item'])]
     private ?CountryCodeAlpha2 $language = null;
 
     #[ORM\Column(enumType: DeckVisibility::class)]
+    #[Groups(['deck:read', 'deck:item'])]
     private ?DeckVisibility $visibility = DeckVisibility::UNLISTED;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 3, scale: 2)]
+    #[Groups(['deck:read', 'deck:item'])]
     private float $rating_avg = 0.00;
 
     #[ORM\Column]
+    #[Groups(['deck:read', 'deck:item'])]
     private int $rating_count = 0;
 
     #[ORM\Column]
+    #[Groups(['deck:read', 'deck:item'])]
     private int $card_count = 0;
 
     #[ORM\Column(enumType: DeckStatus::class)]
+    #[Groups(['deck:read', 'deck:item'])]
     private ?DeckStatus $status = DeckStatus::DRAFT;
 
     /**
      * @var Collection<int, Tag>
      */
     #[ORM\ManyToMany(targetEntity: Tag::class, inversedBy: 'decks')]
+    #[Groups(['deck:read', 'deck:item'])]
     private Collection $tags;
 
     /**
@@ -78,18 +90,21 @@ class Deck
      */
     #[ORM\OneToMany(targetEntity: Card::class, mappedBy: 'deck', cascade: ['persist'], orphanRemoval: true)]
     #[ApiProperty(writableLink: true)]
+    #[Groups(['deck:read', 'deck:item'])]
     private Collection $cards;
 
     /**
      * @var Collection<int, DeckRating>
      */
     #[ORM\OneToMany(targetEntity: DeckRating::class, mappedBy: 'deck', orphanRemoval: true)]
+    #[Groups(['deck:read', 'deck:item'])]
     private Collection $deckRatings;
 
     /**
      * @var Collection<int, DeckComment>
      */
     #[ORM\OneToMany(targetEntity: DeckComment::class, mappedBy: 'deck', orphanRemoval: true)]
+    #[Groups(['deck:read', 'deck:item'])]
     private Collection $deckComments;
 
     public function __construct()

--- a/src/Entity/Traits/UuidTrait.php
+++ b/src/Entity/Traits/UuidTrait.php
@@ -5,6 +5,7 @@ namespace App\Entity\Traits;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Uid\Uuid;
 
 trait UuidTrait
@@ -13,6 +14,7 @@ trait UuidTrait
     #[ORM\Column(type: UuidType::NAME, unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
+    #[Groups(['uuid'])]
     private ?Uuid $id = null;
 
     public function getId(): Uuid


### PR DESCRIPTION
Cette PR ajoute des groupes pour la sérialisation et la récupération de données en front.
Le `content_type` a été supprimé de `card_block`