### PR TITLE
feature: add ScoreEvent and award score for deck publishing

### DIFF
--- a/migrations/Version20250712083648.php
+++ b/migrations/Version20250712083648.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250712083648 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE score_event (id SERIAL NOT NULL, scorer_id UUID NOT NULL, type VARCHAR(255) NOT NULL, value INT NOT NULL, created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_82E2C62F43B35028 ON score_event (scorer_id)');
+        $this->addSql('CREATE INDEX score_event_created_at_idx ON score_event (created_at)');
+        $this->addSql('COMMENT ON COLUMN score_event.scorer_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN score_event.created_at IS \'(DC2Type:datetimetz_immutable)\'');
+        $this->addSql('ALTER TABLE score_event ADD CONSTRAINT FK_82E2C62F43B35028 FOREIGN KEY (scorer_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE score_event DROP CONSTRAINT FK_82E2C62F43B35028');
+        $this->addSql('DROP TABLE score_event');
+    }
+}

--- a/src/Entity/ScoreEvent.php
+++ b/src/Entity/ScoreEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use App\Enum\ScoreEventType;
+use App\Repository\ScoreEventRepository;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity(repositoryClass: ScoreEventRepository::class)]
+#[ORM\Index(name: "score_event_created_at_idx", columns: ["created_at"])]
+#[ApiResource]
+class ScoreEvent
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'scoreEvents')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $scorer = null;
+
+    #[ORM\Column(enumType: ScoreEventType::class)]
+    private ?ScoreEventType $type = null;
+
+    #[ORM\Column]
+    private ?int $value = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
+    private ?DateTimeImmutable $created_at = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getScorer(): ?User
+    {
+        return $this->scorer;
+    }
+
+    public function setScorer(?User $scorer): static
+    {
+        $this->scorer = $scorer;
+
+        return $this;
+    }
+
+    public function getType(): ?ScoreEventType
+    {
+        return $this->type;
+    }
+
+    public function setType(ScoreEventType $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getValue(): ?int
+    {
+        return $this->value;
+    }
+
+    public function setValue(int $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?DateTimeImmutable
+    {
+        return $this->created_at;
+    }
+
+    public function setCreatedAt(DateTimeImmutable $created_at): static
+    {
+        $this->created_at = $created_at;
+
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -79,6 +79,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: DeckComment::class, mappedBy: 'commenter')]
     private Collection $deckComments;
 
+    /**
+     * @var Collection<int, ScoreEvent>
+     */
+    #[ORM\OneToMany(targetEntity: ScoreEvent::class, mappedBy: 'scorer', orphanRemoval: true)]
+    private Collection $scoreEvents;
+
     public function __construct()
     {
         $this->userBadges = new ArrayCollection();
@@ -87,6 +93,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->decks = new ArrayCollection();
         $this->deckRatings = new ArrayCollection();
         $this->deckComments = new ArrayCollection();
+        $this->scoreEvents = new ArrayCollection();
     }
 
     public function getEmail(): ?string
@@ -355,6 +362,36 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
             // set the owning side to null (unless already changed)
             if ($deckComment->getCommenter() === $this) {
                 $deckComment->setCommenter(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ScoreEvent>
+     */
+    public function getScoreEvents(): Collection
+    {
+        return $this->scoreEvents;
+    }
+
+    public function addScoreEvent(ScoreEvent $scoreEvent): static
+    {
+        if (!$this->scoreEvents->contains($scoreEvent)) {
+            $this->scoreEvents->add($scoreEvent);
+            $scoreEvent->setScorer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeScoreEvent(ScoreEvent $scoreEvent): static
+    {
+        if ($this->scoreEvents->removeElement($scoreEvent)) {
+            // set the owning side to null (unless already changed)
+            if ($scoreEvent->getScorer() === $this) {
+                $scoreEvent->setScorer(null);
             }
         }
 

--- a/src/Enum/ScoreEventType.php
+++ b/src/Enum/ScoreEventType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enum;
+
+enum ScoreEventType: string
+{
+    case DECK_PUBLISH = 'deck_publish';
+    case DAILY_LOGIN = 'daily_login';
+    case COMPLETE_STUDY_SESSION = 'complete_study_session';
+    case STREAK_MILESTONE = 'streak_milestone';
+    case PROFILE_COMPLETE = 'profile_complete';
+    case ACHIEVEMENT_UNLOCK = 'achievement_unlock';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::DECK_PUBLISH => 'Publish a deck',
+            self::DAILY_LOGIN => 'Daily login',
+            self::COMPLETE_STUDY_SESSION => 'Complete study session',
+            self::STREAK_MILESTONE => 'Reach a streak milestone',
+            self::PROFILE_COMPLETE => 'Complete profile',
+            self::ACHIEVEMENT_UNLOCK => 'Unlock an achievement',
+        };
+    }
+
+    public function getDefaultPoints(): int
+    {
+        return match ($this) {
+            self::DECK_PUBLISH => 20,
+            self::DAILY_LOGIN => 10,
+            self::COMPLETE_STUDY_SESSION => 25,
+            self::STREAK_MILESTONE => 50,
+            self::PROFILE_COMPLETE => 30,
+            self::ACHIEVEMENT_UNLOCK => 40,
+        };
+    }
+}

--- a/src/EventSubscriber/DeckPublishedSubscriber.php
+++ b/src/EventSubscriber/DeckPublishedSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Deck;
+use App\Enum\DeckStatus;
+use App\Enum\ScoreEventType;
+use App\Service\ScoreLogger;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+#[AsDoctrineListener(event: 'postUpdate')]
+#[AsDoctrineListener(event: 'postPersist')]
+final readonly class DeckPublishedSubscriber
+{
+    public function __construct(
+        private ScoreLogger $scoreLogger,
+    )
+    {
+    }
+
+    public function postPersist(LifecycleEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Deck) {
+            return;
+        }
+
+        // Check if the deck is being created with PUBLISHED status
+        if ($entity->getStatus() === DeckStatus::PUBLISHED->value) {
+            $owner = $entity->getOwner();
+
+            if ($owner) {
+                $this->scoreLogger->log($owner, ScoreEventType::DECK_PUBLISH, null, false);
+            }
+        }
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Deck) {
+            return;
+        }
+
+        // Get the change set from unit of work
+        $uow = $args->getObjectManager()->getUnitOfWork();
+        $changeSet = $uow->getEntityChangeSet($entity);
+
+        if (!isset($changeSet['status'])) {
+            return;
+        }
+
+        [$oldStatus, $newStatus] = $changeSet['status'];
+
+        // Only award points when transitioning to PUBLISHED status
+        if ($oldStatus !== DeckStatus::PUBLISHED->value && $newStatus === DeckStatus::PUBLISHED->value) {
+            $owner = $entity->getOwner();
+
+            if ($owner) {
+                $this->scoreLogger->log($owner, ScoreEventType::DECK_PUBLISH);
+            }
+        }
+    }
+}

--- a/src/Repository/ScoreEventRepository.php
+++ b/src/Repository/ScoreEventRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ScoreEvent;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ScoreEvent>
+ */
+class ScoreEventRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ScoreEvent::class);
+    }
+
+    //    /**
+    //     * @return ScoreEvent[] Returns an array of ScoreEvent objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('s.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?ScoreEvent
+    //    {
+    //        return $this->createQueryBuilder('s')
+    //            ->andWhere('s.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/src/Service/ScoreLogger.php
+++ b/src/Service/ScoreLogger.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\ScoreEvent;
+use App\Entity\User;
+use App\Enum\ScoreEventType;
+use Doctrine\ORM\EntityManagerInterface;
+
+readonly class ScoreLogger
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager
+    )
+    {
+    }
+
+    /**
+     * Log multiple score events for a user
+     *
+     * @return ScoreEvent[]
+     */
+    public function logMultiple(User $user, array $events): array
+    {
+        $scoreEvents = [];
+
+        foreach ($events as $event) {
+            $type = $event['type'];
+            $value = $event['value'] ?? null;
+
+            $scoreEvents[] = $this->log($user, $type, $value);
+        }
+
+        return $scoreEvents;
+    }
+
+    /**
+     * Log a score event for a user
+     */
+    public function log(User $user, ScoreEventType $type, ?int $value = null): ScoreEvent
+    {
+        // Use default points if value is not provided
+        $points = $value ?? $type->getDefaultPoints();
+
+        $scoreEvent = new ScoreEvent();
+        $scoreEvent->setScorer($user);
+        $scoreEvent->setType($type);
+        $scoreEvent->setValue($points);
+
+        $this->entityManager->persist($scoreEvent);
+        $this->entityManager->flush();
+
+        return $scoreEvent;
+    }
+
+    /**
+     * Calculate total score for a user
+     */
+    public function calculateTotalScore(User $user): int
+    {
+        return $this->entityManager->getRepository(ScoreEvent::class)
+            ->createQueryBuilder('se')
+            ->select('SUM(se.value)')
+            ->where('se.scorer = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult() ?: 0;
+    }
+}


### PR DESCRIPTION
Cette PR ajoute l'entité `ScoreEvent` qui sera utilisé pour garder un historique des points gagné par un utilisateur.
De plus le premier event sur la publication d'un deck a été mis en place, des points sont récompensé.