### PR TITLE
feature: review queue

### DIFF
--- a/migrations/Version20250713082300.php
+++ b/migrations/Version20250713082300.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250713082300 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE review_queue (id UUID NOT NULL, owner_id UUID NOT NULL, deck_id UUID NOT NULL, priority VARCHAR(255) DEFAULT \'normal\' NOT NULL, added_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_6C7353787E3C61F9 ON review_queue (owner_id)');
+        $this->addSql('CREATE INDEX IDX_6C735378111948DC ON review_queue (deck_id)');
+        $this->addSql('CREATE UNIQUE INDEX owner_deck_unique ON review_queue (owner_id, deck_id)');
+        $this->addSql('COMMENT ON COLUMN review_queue.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_queue.owner_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_queue.deck_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_queue.added_at IS \'(DC2Type:datetimetz_immutable)\'');
+        $this->addSql('ALTER TABLE review_queue ADD CONSTRAINT FK_6C7353787E3C61F9 FOREIGN KEY (owner_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE review_queue ADD CONSTRAINT FK_6C735378111948DC FOREIGN KEY (deck_id) REFERENCES deck (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE review_queue DROP CONSTRAINT FK_6C7353787E3C61F9');
+        $this->addSql('ALTER TABLE review_queue DROP CONSTRAINT FK_6C735378111948DC');
+        $this->addSql('DROP TABLE review_queue');
+    }
+}

--- a/src/Controller/UserReviewQueueController.php
+++ b/src/Controller/UserReviewQueueController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ReviewQueue;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Serializer\Context\Normalizer\ObjectNormalizerContextBuilder;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class UserReviewQueueController extends AbstractController
+{
+    #[Route('/api/my-review-queues', name: 'api_my_review_queues', methods: ['GET'])]
+    public function getUserReviewQueues(
+        #[CurrentUser] ?User   $user,
+        EntityManagerInterface $entityManager,
+        SerializerInterface    $serializer
+    ): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $reviewQueues = $entityManager->getRepository(ReviewQueue::class)->findBy(['owner' => $user]);
+
+        $context = new ObjectNormalizerContextBuilder()
+            ->withGroups(['queue:item', 'uuid'])
+            ->toArray();
+
+        $reviewQueuesData = $serializer->normalize($reviewQueues, null, $context);
+
+        return $this->json($reviewQueuesData);
+    }
+
+    #[Route('/api/my-review-queues/{id}', name: 'api_my_review_queue', methods: ['GET'])]
+    public function getUserReviewQueue(
+        #[CurrentUser] ?User   $user,
+        string                 $id,
+        EntityManagerInterface $entityManager,
+        SerializerInterface    $serializer
+    ): JsonResponse
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $reviewQueue = $entityManager->getRepository(ReviewQueue::class)->findOneBy([
+            'id' => $id,
+            'owner' => $user
+        ]);
+
+        if (!$reviewQueue) {
+            return $this->json(['message' => 'Review queue not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $context = new ObjectNormalizerContextBuilder()
+            ->withGroups(['queue:read', 'queue:item', 'uuid'])
+            ->toArray();
+
+        $reviewQueueData = $serializer->normalize($reviewQueue, null, $context);
+
+        return $this->json($reviewQueueData);
+    }
+}

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -115,12 +115,19 @@ class Deck
     #[Groups(['deck:read', 'deck:item'])]
     private Collection $deckComments;
 
+    /**
+     * @var Collection<int, ReviewQueue>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewQueue::class, mappedBy: 'deck', orphanRemoval: true)]
+    private Collection $reviewQueues;
+
     public function __construct()
     {
         $this->tags = new ArrayCollection();
         $this->cards = new ArrayCollection();
         $this->deckRatings = new ArrayCollection();
         $this->deckComments = new ArrayCollection();
+        $this->reviewQueues = new ArrayCollection();
     }
 
     public function getOwner(): ?User
@@ -339,6 +346,36 @@ class Deck
             // set the owning side to null (unless already changed)
             if ($deckComment->getDeck() === $this) {
                 $deckComment->setDeck(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewQueue>
+     */
+    public function getReviewQueues(): Collection
+    {
+        return $this->reviewQueues;
+    }
+
+    public function addReviewQueue(ReviewQueue $reviewQueue): static
+    {
+        if (!$this->reviewQueues->contains($reviewQueue)) {
+            $this->reviewQueues->add($reviewQueue);
+            $reviewQueue->setDeck($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewQueue(ReviewQueue $reviewQueue): static
+    {
+        if ($this->reviewQueues->removeElement($reviewQueue)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewQueue->getDeck() === $this) {
+                $reviewQueue->setDeck(null);
             }
         }
 

--- a/src/Entity/ReviewQueue.php
+++ b/src/Entity/ReviewQueue.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use App\Entity\Traits\UuidTrait;
+use App\Enum\ReviewPriority;
+use App\Repository\ReviewQueueRepository;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ORM\Entity(repositoryClass: ReviewQueueRepository::class)]
+#[ORM\UniqueConstraint(name: 'owner_deck_unique', columns: ['owner_id', 'deck_id'])]
+#[ApiResource(
+    operations: [
+        new Get(
+            normalizationContext: ['groups' => ['queue:read', 'queue:item', 'uuid']],
+            security: "object.getOwner() == user"
+        ),
+        new GetCollection(
+            normalizationContext: ['groups' => ['queue:read', 'uuid']],
+            security: "is_granted('ROLE_ADMIN')"
+        ),
+        new Post(
+            normalizationContext: ['groups' => ['queue:read', 'queue:item', 'uuid']],
+            denormalizationContext: ['groups' => ['queue:write']],
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Put(
+            normalizationContext: ['groups' => ['queue:read', 'queue:item', 'uuid']],
+            denormalizationContext: ['groups' => ['queue:update']],
+            security: "object.getOwner() == user"
+        ),
+        new Delete(
+            security: "object.getOwner() == user"
+        ),
+    ]
+)]
+class ReviewQueue
+{
+    use UuidTrait;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewQueues')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['queue:read'])]
+    private ?User $owner = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewQueues')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['queue:read', 'queue:write', 'queue:item'])]
+    private ?Deck $deck = null;
+
+    #[ORM\Column(enumType: ReviewPriority::class, options: ["default" => ReviewPriority::NORMAL])]
+    #[Groups(['queue:read', 'queue:write', 'queue:update', 'queue:item'])]
+    private ?ReviewPriority $priority = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
+    #[Groups(['queue:read', 'queue:item'])]
+    private ?DateTimeImmutable $added_at = null;
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): static
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getDeck(): ?Deck
+    {
+        return $this->deck;
+    }
+
+    public function setDeck(?Deck $deck): static
+    {
+        $this->deck = $deck;
+
+        return $this;
+    }
+
+    public function getPriority(): ?ReviewPriority
+    {
+        return $this->priority;
+    }
+
+    public function setPriority(ReviewPriority $priority): static
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    public function getAddedAt(): ?DateTimeImmutable
+    {
+        return $this->added_at;
+    }
+
+    public function setAddedAt(DateTimeImmutable $added_at): static
+    {
+        $this->added_at = $added_at;
+
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -114,6 +114,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(options: ["default" => 0])]
     private ?int $score = 0;
 
+    /**
+     * @var Collection<int, ReviewQueue>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewQueue::class, mappedBy: 'owner', orphanRemoval: true)]
+    private Collection $reviewQueues;
+
     public function __construct()
     {
         $this->userBadges = new ArrayCollection();
@@ -123,6 +129,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->deckRatings = new ArrayCollection();
         $this->deckComments = new ArrayCollection();
         $this->scoreEvents = new ArrayCollection();
+        $this->reviewQueues = new ArrayCollection();
     }
 
     public function getEmail(): ?string
@@ -522,6 +529,36 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $scoreInLevel = $currentScore - $currentLevelThreshold;
 
         return min(100.0, round(($scoreInLevel / $levelRange) * 100, 1));
+    }
+
+    /**
+     * @return Collection<int, ReviewQueue>
+     */
+    public function getReviewQueues(): Collection
+    {
+        return $this->reviewQueues;
+    }
+
+    public function addReviewQueue(ReviewQueue $reviewQueue): static
+    {
+        if (!$this->reviewQueues->contains($reviewQueue)) {
+            $this->reviewQueues->add($reviewQueue);
+            $reviewQueue->setOwner($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewQueue(ReviewQueue $reviewQueue): static
+    {
+        if ($this->reviewQueues->removeElement($reviewQueue)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewQueue->getOwner() === $this) {
+                $reviewQueue->setOwner(null);
+            }
+        }
+
+        return $this;
     }
 
 }

--- a/src/Enum/ReviewPriority.php
+++ b/src/Enum/ReviewPriority.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enum;
+
+enum ReviewPriority: string
+{
+    case NORMAL = 'normal';
+    case INTENSE = 'intense';
+
+    public static function getValues(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function getOptions(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->getLabel()] = $case->value;
+        }
+        return $options;
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NORMAL => 'Normal',
+            self::INTENSE => 'Intense',
+        };
+    }
+}

--- a/src/EventSubscriber/ReviewQueueSubscriber.php
+++ b/src/EventSubscriber/ReviewQueueSubscriber.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use ApiPlatform\Symfony\EventListener\EventPriorities;
+use App\Entity\ReviewQueue;
+use App\Enum\DeckStatus;
+use App\Enum\DeckVisibility;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ReviewQueueSubscriber implements EventSubscriberInterface
+{
+    private Security $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW => [
+                ['setOwner', EventPriorities::PRE_VALIDATE],
+                ['validateDeckEligibility', EventPriorities::PRE_VALIDATE],
+            ],
+        ];
+    }
+
+    public function setOwner(ViewEvent $event): void
+    {
+        $reviewQueue = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        // Only process POST requests for ReviewQueue entities
+        if (!$reviewQueue instanceof ReviewQueue || Request::METHOD_POST !== $method) {
+            return;
+        }
+
+        // Set the current authenticated user as the owner
+        $currentUser = $this->security->getUser();
+        $reviewQueue->setOwner($currentUser);
+    }
+
+    public function validateDeckEligibility(ViewEvent $event): void
+    {
+        $reviewQueue = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        // Only process POST requests for ReviewQueue entities
+        if (!$reviewQueue instanceof ReviewQueue || Request::METHOD_POST !== $method) {
+            return;
+        }
+
+        $deck = $reviewQueue->getDeck();
+        if (!$deck) {
+            throw new AccessDeniedHttpException('No deck specified.');
+        }
+
+        $currentUser = $this->security->getUser();
+
+        // Allow if the user is the owner of the deck
+        if ($deck->getOwner() === $currentUser) {
+            return;
+        }
+
+        // Check if deck is published
+        if ($deck->getStatus() !== DeckStatus::PUBLISHED) {
+            throw new AccessDeniedHttpException('This deck is not published and cannot be added to your review queue.');
+        }
+
+        // Check if deck is public
+        if ($deck->getVisibility() !== DeckVisibility::PUBLIC) {
+            throw new AccessDeniedHttpException('This deck is not public and cannot be added to your review queue.');
+        }
+    }
+}

--- a/src/Repository/ReviewQueueRepository.php
+++ b/src/Repository/ReviewQueueRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReviewQueue;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReviewQueue>
+ */
+class ReviewQueueRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReviewQueue::class);
+    }
+
+    //    /**
+    //     * @return ReviewQueue[] Returns an array of ReviewQueue objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('r.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?ReviewQueue
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}


### PR DESCRIPTION
Cette PR ajoute les `ReviewQueue` et les routes correspondantes.
Pour récupérer celles de l'utilisateur connecté: `/api/my-review-queues`.
Des restrictions on été mis en place, un deck doit être `public` et `published` (exception pour l'auteur) afin d'être ajouté.