### PR TITLE
feature: review queue adjust response for frontend

### DIFF
--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -53,11 +53,11 @@ class Deck
     private ?User $owner = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['deck:read', 'deck:item'])]
+    #[Groups(['deck:read', 'deck:item', 'queue:item'])]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
-    #[Groups(['deck:read', 'deck:item'])]
+    #[Groups(['deck:read', 'deck:item', 'queue:item'])]
     private ?string $description = null;
 
     #[ORM\Column(nullable: true, enumType: CountryCodeAlpha2::class)]
@@ -78,7 +78,7 @@ class Deck
     private int $rating_count = 0;
 
     #[ORM\Column]
-    #[Groups(['deck:read', 'deck:item'])]
+    #[Groups(['deck:read', 'deck:item', 'queue:item'])]
     private int $card_count = 0;
 
     #[ORM\Column(enumType: DeckStatus::class)]

--- a/src/EventSubscriber/ReviewQueueSubscriber.php
+++ b/src/EventSubscriber/ReviewQueueSubscriber.php
@@ -6,20 +6,23 @@ use ApiPlatform\Symfony\EventListener\EventPriorities;
 use App\Entity\ReviewQueue;
 use App\Enum\DeckStatus;
 use App\Enum\DeckVisibility;
+use App\Enum\ReviewPriority;
+use App\Repository\ReviewQueueRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ReviewQueueSubscriber implements EventSubscriberInterface
+readonly class ReviewQueueSubscriber implements EventSubscriberInterface
 {
-    private Security $security;
-
-    public function __construct(Security $security)
+    public function __construct(
+        private Security              $security,
+        private ReviewQueueRepository $reviewQueueRepository
+    )
     {
-        $this->security = $security;
     }
 
     public static function getSubscribedEvents(): array
@@ -28,23 +31,9 @@ class ReviewQueueSubscriber implements EventSubscriberInterface
             KernelEvents::VIEW => [
                 ['setOwner', EventPriorities::PRE_VALIDATE],
                 ['validateDeckEligibility', EventPriorities::PRE_VALIDATE],
+                ['handleReviewQueue', EventPriorities::PRE_WRITE],
             ],
         ];
-    }
-
-    public function setOwner(ViewEvent $event): void
-    {
-        $reviewQueue = $event->getControllerResult();
-        $method = $event->getRequest()->getMethod();
-
-        // Only process POST requests for ReviewQueue entities
-        if (!$reviewQueue instanceof ReviewQueue || Request::METHOD_POST !== $method) {
-            return;
-        }
-
-        // Set the current authenticated user as the owner
-        $currentUser = $this->security->getUser();
-        $reviewQueue->setOwner($currentUser);
     }
 
     public function validateDeckEligibility(ViewEvent $event): void
@@ -69,14 +58,78 @@ class ReviewQueueSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Check if deck is published
         if ($deck->getStatus() !== DeckStatus::PUBLISHED) {
             throw new AccessDeniedHttpException('This deck is not published and cannot be added to your review queue.');
         }
 
-        // Check if deck is public
         if ($deck->getVisibility() !== DeckVisibility::PUBLIC) {
             throw new AccessDeniedHttpException('This deck is not public and cannot be added to your review queue.');
         }
+    }
+
+    public function handleReviewQueue(ViewEvent $event): void
+    {
+        $reviewQueue = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        if (!$reviewQueue instanceof ReviewQueue) {
+            return;
+        }
+
+        if (Request::METHOD_POST === $method) {
+            $currentUser = $this->security->getUser();
+            $reviewQueue->setOwner($currentUser);
+
+            if (null === $reviewQueue->getPriority()) {
+                $reviewQueue->setPriority(ReviewPriority::NORMAL);
+            }
+
+            $deck = $reviewQueue->getDeck();
+            if (!$deck) {
+                throw new BadRequestHttpException('No deck specified.');
+            }
+
+            // Check if the deck is already in the user's review queue
+            $existingQueue = $this->reviewQueueRepository->findOneBy([
+                'owner' => $currentUser,
+                'deck' => $deck
+            ]);
+
+            if ($existingQueue) {
+                throw new BadRequestHttpException('This deck is already in your review queue.');
+            }
+
+            // Allow if the user is the owner of the deck
+            if ($deck->getOwner() !== $currentUser) {
+                if ($deck->getStatus() !== DeckStatus::PUBLISHED) {
+                    throw new AccessDeniedHttpException('This deck is not published and cannot be added to your review queue.');
+                }
+
+                if ($deck->getVisibility() !== DeckVisibility::PUBLIC) {
+                    throw new AccessDeniedHttpException('This deck is not public and cannot be added to your review queue.');
+                }
+            }
+        } else if (Request::METHOD_PUT === $method) {
+            $request = $event->getRequest();
+            $data = json_decode($request->getContent(), true);
+
+            // Prevent deck modification
+            if (isset($data['deck'])) {
+                throw new AccessDeniedHttpException('Deck cannot be modified after creation.');
+            }
+        }
+    }
+
+    public function setOwner(ViewEvent $event): void
+    {
+        $reviewQueue = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        if (!$reviewQueue instanceof ReviewQueue || Request::METHOD_POST !== $method) {
+            return;
+        }
+
+        $currentUser = $this->security->getUser();
+        $reviewQueue->setOwner($currentUser);
     }
 }


### PR DESCRIPTION
Ajoute une restriction plus claire sur un deck déjà dans la file de révision.
Fixe la priorité vide lors d'un POST.
Ajuste la réponse API avec le contenu d'un deck.

Lié à [ff-app#98](https://github.com/FichesFlow/ff-app/pull/98)