### PR TITLE
feature: review_session and review_event

### DIFF
--- a/migrations/Version20250716123436.php
+++ b/migrations/Version20250716123436.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250716123436 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE review_event (id UUID NOT NULL, session_id UUID NOT NULL, reviewer_id UUID NOT NULL, card_id UUID NOT NULL, score SMALLINT NOT NULL, reviewed_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_282026BC613FECDF ON review_event (session_id)');
+        $this->addSql('CREATE INDEX IDX_282026BC70574616 ON review_event (reviewer_id)');
+        $this->addSql('CREATE INDEX IDX_282026BC4ACC9A20 ON review_event (card_id)');
+        $this->addSql('COMMENT ON COLUMN review_event.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_event.session_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_event.reviewer_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_event.card_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('CREATE TABLE review_session (id UUID NOT NULL, reviewer_id UUID NOT NULL, deck_id UUID DEFAULT NULL, mode VARCHAR(255) NOT NULL, started_at TIMESTAMP(0) WITH TIME ZONE NOT NULL, finished_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL, cards_seen INT DEFAULT 0 NOT NULL, success_pct NUMERIC(5, 2) DEFAULT \'0.00\' NOT NULL, xp_gained INT DEFAULT 0 NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_4BAA612370574616 ON review_session (reviewer_id)');
+        $this->addSql('CREATE INDEX IDX_4BAA6123111948DC ON review_session (deck_id)');
+        $this->addSql('COMMENT ON COLUMN review_session.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_session.reviewer_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_session.deck_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN review_session.started_at IS \'(DC2Type:datetimetz_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN review_session.finished_at IS \'(DC2Type:datetimetz_immutable)\'');
+        $this->addSql('ALTER TABLE review_event ADD CONSTRAINT FK_282026BC613FECDF FOREIGN KEY (session_id) REFERENCES review_session (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE review_event ADD CONSTRAINT FK_282026BC70574616 FOREIGN KEY (reviewer_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE review_event ADD CONSTRAINT FK_282026BC4ACC9A20 FOREIGN KEY (card_id) REFERENCES card (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE review_session ADD CONSTRAINT FK_4BAA612370574616 FOREIGN KEY (reviewer_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE review_session ADD CONSTRAINT FK_4BAA6123111948DC FOREIGN KEY (deck_id) REFERENCES deck (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE review_event DROP CONSTRAINT FK_282026BC613FECDF');
+        $this->addSql('ALTER TABLE review_event DROP CONSTRAINT FK_282026BC70574616');
+        $this->addSql('ALTER TABLE review_event DROP CONSTRAINT FK_282026BC4ACC9A20');
+        $this->addSql('ALTER TABLE review_session DROP CONSTRAINT FK_4BAA612370574616');
+        $this->addSql('ALTER TABLE review_session DROP CONSTRAINT FK_4BAA6123111948DC');
+        $this->addSql('DROP TABLE review_event');
+        $this->addSql('DROP TABLE review_session');
+    }
+}

--- a/src/Controller/ReviewSessionController.php
+++ b/src/Controller/ReviewSessionController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ReviewSession;
+use App\Entity\User;
+use App\Enum\ReviewMode;
+use App\Enum\ScoreEventType;
+use App\Repository\CardRepository;
+use App\Repository\DeckRepository;
+use App\Repository\ReviewSessionRepository;
+use App\Service\ScoreLogger;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Serializer\Context\Normalizer\ObjectNormalizerContextBuilder;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ReviewSessionController extends AbstractController
+{
+    #[Route('/api/review_sessions/start', name: 'api_review_sessions_start', methods: ['POST'])]
+    public function start(
+        #[CurrentUser] ?User   $user,
+        Request                $request,
+        EntityManagerInterface $entityManager,
+        DeckRepository         $deckRepository,
+        CardRepository         $cardRepository,
+        ValidatorInterface     $validator
+    ): Response
+    {
+        if ($request->getContent() === '') {
+            throw new BadRequestHttpException('Request body cannot be empty');
+        }
+
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $data = json_decode($request->getContent(), true);
+
+        // Validate request
+        $constraints = new Assert\Collection([
+            'deck' => [new Assert\NotBlank(), new Assert\Uuid()],
+            'mode' => [new Assert\NotBlank(), new Assert\Choice(choices: ['flashcard', 'qcm'])],
+            'cards' => [
+                new Assert\NotBlank(),
+                new Assert\Type('array'),
+                new Assert\Count(['min' => 1]),
+                new Assert\All([
+                    new Assert\Uuid()
+                ])
+            ],
+        ]);
+
+        $violations = $validator->validate($data, $constraints);
+        if (count($violations) > 0) {
+            throw new BadRequestHttpException((string)$violations);
+        }
+
+        if (!$deck = $deckRepository->find($data['deck'])) {
+            throw $this->createNotFoundException('Deck not found');
+        }
+
+        // Get cards by provided IDs, ensuring they belong to the specified deck
+        $cards = $cardRepository->findBy([
+            'id' => $data['cards'],
+            'deck' => $deck
+        ]);
+
+        // Check if all requested cards were found
+        if (count($cards) !== count($data['cards'])) {
+            throw new BadRequestHttpException('Some requested cards were not found or do not belong to the specified deck');
+        }
+
+        // Create a review session
+        $reviewSession = new ReviewSession();
+        $reviewSession->setReviewer($user);
+        $reviewSession->setDeck($deck);
+        $reviewSession->setMode(ReviewMode::from($data['mode']));
+
+        $entityManager->persist($reviewSession);
+        $entityManager->flush();
+
+        $response = [
+            'id' => $reviewSession->getId()
+        ];
+
+        return $this->json($response, Response::HTTP_CREATED);
+    }
+
+    #[Route('/api/review_sessions/{id}/finish', name: 'api_review_sessions_finish', methods: ['POST'])]
+    public function finish(
+        string                  $id,
+        #[CurrentUser] ?User    $user,
+        EntityManagerInterface  $entityManager,
+        ReviewSessionRepository $reviewSessionRepository,
+        ScoreLogger             $scoreLogger,
+        SerializerInterface     $serializer
+    ): Response
+    {
+        if (!$user) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $reviewSession = $reviewSessionRepository->find($id);
+        if (!$reviewSession) {
+            return $this->json(['message' => 'Review session not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        if ($reviewSession->getReviewer() !== $user) {
+            return $this->json(['message' => 'You can only finish your own review sessions'], Response::HTTP_FORBIDDEN);
+        }
+
+        if ($reviewSession->getFinishedAt() !== null) {
+            return $this->json(['message' => 'This review session is already finished'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $reviewSession->setFinishedAt(new DateTimeImmutable());
+
+        // Calculate final success percentage
+        $totalScore = 0;
+        $cardsSeen = $reviewSession->getCardsSeen();
+        $goodCards = 0;
+
+        foreach ($reviewSession->getReviewEvents() as $event) {
+            $score = $event->getScore();
+            $totalScore += $score;
+
+            // Count cards with score >= 3 for XP calculation
+            if ($score >= 3) {
+                $goodCards++;
+            }
+        }
+
+        // Calculate percentage (max score would be 5 points per card)
+        $successPct = $cardsSeen > 0 ? ($totalScore / ($cardsSeen * 5)) * 100 : 0;
+        $reviewSession->setSuccessPct($successPct);
+
+        // Calculate XP gained (2 XP per card with score >= 3)
+        $xpGained = $goodCards * 2;
+        $reviewSession->setXpGained($xpGained);
+
+        if ($xpGained > 0) {
+            $scoreLogger->log($user, ScoreEventType::COMPLETE_STUDY_SESSION, $xpGained);
+        }
+
+        $entityManager->persist($reviewSession);
+        $entityManager->flush();
+
+        $context = new ObjectNormalizerContextBuilder()
+            ->withGroups(['review_session:read', 'review_session:item'])
+            ->toArray();
+
+        $reviewSessionData = $serializer->normalize($reviewSession, null, $context);
+
+        return $this->json($reviewSessionData, Response::HTTP_OK);
+    }
+}

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -37,9 +37,16 @@ class Card
     #[Groups(['deck:item'])]
     private Collection $cardSides;
 
+    /**
+     * @var Collection<int, ReviewEvent>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewEvent::class, mappedBy: 'card', orphanRemoval: true)]
+    private Collection $reviewEvents;
+
     public function __construct()
     {
         $this->cardSides = new ArrayCollection();
+        $this->reviewEvents = new ArrayCollection();
     }
 
     public function getDeck(): ?Deck
@@ -90,6 +97,36 @@ class Card
             // set the owning side to null (unless already changed)
             if ($cardSide->getCard() === $this) {
                 $cardSide->setCard(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewEvent>
+     */
+    public function getReviewEvents(): Collection
+    {
+        return $this->reviewEvents;
+    }
+
+    public function addReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if (!$this->reviewEvents->contains($reviewEvent)) {
+            $this->reviewEvents->add($reviewEvent);
+            $reviewEvent->setCard($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if ($this->reviewEvents->removeElement($reviewEvent)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewEvent->getCard() === $this) {
+                $reviewEvent->setCard(null);
             }
         }
 

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -125,6 +125,12 @@ class Deck
     #[ORM\OneToMany(targetEntity: ReviewQueue::class, mappedBy: 'deck', orphanRemoval: true)]
     private Collection $reviewQueues;
 
+    /**
+     * @var Collection<int, ReviewSession>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewSession::class, mappedBy: 'deck')]
+    private Collection $reviewSessions;
+
     public function __construct()
     {
         $this->tags = new ArrayCollection();
@@ -132,6 +138,7 @@ class Deck
         $this->deckRatings = new ArrayCollection();
         $this->deckComments = new ArrayCollection();
         $this->reviewQueues = new ArrayCollection();
+        $this->reviewSessions = new ArrayCollection();
     }
 
     public function getOwner(): ?User
@@ -380,6 +387,36 @@ class Deck
             // set the owning side to null (unless already changed)
             if ($reviewQueue->getDeck() === $this) {
                 $reviewQueue->setDeck(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewSession>
+     */
+    public function getReviewSessions(): Collection
+    {
+        return $this->reviewSessions;
+    }
+
+    public function addReviewSession(ReviewSession $reviewSession): static
+    {
+        if (!$this->reviewSessions->contains($reviewSession)) {
+            $this->reviewSessions->add($reviewSession);
+            $reviewSession->setDeck($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewSession(ReviewSession $reviewSession): static
+    {
+        if ($this->reviewSessions->removeElement($reviewSession)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewSession->getDeck() === $this) {
+                $reviewSession->setDeck(null);
             }
         }
 

--- a/src/Entity/ReviewEvent.php
+++ b/src/Entity/ReviewEvent.php
@@ -3,21 +3,36 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 use App\Entity\Traits\UuidTrait;
 use App\Repository\ReviewEventRepository;
 use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ReviewEventRepository::class)]
-#[ApiResource]
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Post(
+            denormalizationContext: ['groups' => ['review_event:create']],
+            validationContext: ['groups' => ['Default', 'review_event:create']]
+        )
+    ]
+)]
 class ReviewEvent
 {
     use UuidTrait;
 
     #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['review_event:create'])]
     private ?ReviewSession $session = null;
 
     #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
@@ -26,9 +41,14 @@ class ReviewEvent
 
     #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Assert\NotNull(groups: ['review_event:create'])]
+    #[Groups(['review_event:create'])]
     private ?Card $card = null;
 
     #[ORM\Column(type: Types::SMALLINT)]
+    #[Assert\Choice(choices: [0, 3, 5], groups: ['review_event:create'])]
+    #[Assert\NotNull(groups: ['review_event:create'])]
+    #[Groups(['review_event:create'])]
     private ?int $score = null;
 
     #[ORM\Column(type: Types::DATETIMETZ_MUTABLE)]

--- a/src/Entity/ReviewEvent.php
+++ b/src/Entity/ReviewEvent.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Traits\UuidTrait;
+use App\Repository\ReviewEventRepository;
+use DateTime;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity(repositoryClass: ReviewEventRepository::class)]
+#[ApiResource]
+class ReviewEvent
+{
+    use UuidTrait;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?ReviewSession $session = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $reviewer = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewEvents')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Card $card = null;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private ?int $score = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_MUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
+    private ?DateTime $reviewed_at = null;
+
+    public function getSession(): ?ReviewSession
+    {
+        return $this->session;
+    }
+
+    public function setSession(?ReviewSession $session): static
+    {
+        $this->session = $session;
+
+        return $this;
+    }
+
+    public function getReviewer(): ?User
+    {
+        return $this->reviewer;
+    }
+
+    public function setReviewer(?User $reviewer): static
+    {
+        $this->reviewer = $reviewer;
+
+        return $this;
+    }
+
+    public function getCard(): ?Card
+    {
+        return $this->card;
+    }
+
+    public function setCard(?Card $card): static
+    {
+        $this->card = $card;
+
+        return $this;
+    }
+
+    public function getScore(): ?int
+    {
+        return $this->score;
+    }
+
+    public function setScore(int $score): static
+    {
+        $this->score = $score;
+
+        return $this;
+    }
+
+    public function getReviewedAt(): ?DateTime
+    {
+        return $this->reviewed_at;
+    }
+
+    public function setReviewedAt(DateTime $reviewed_at): static
+    {
+        $this->reviewed_at = $reviewed_at;
+
+        return $this;
+    }
+}

--- a/src/Entity/ReviewSession.php
+++ b/src/Entity/ReviewSession.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 use App\Entity\Traits\UuidTrait;
 use App\Enum\ReviewMode;
 use App\Repository\ReviewSessionRepository;
@@ -12,37 +14,51 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: ReviewSessionRepository::class)]
-#[ApiResource]
+#[ApiResource(
+    operations: [
+        new Get(normalizationContext: ['groups' => ['review_session:read', 'review_session:item', 'uuid']]),
+        new GetCollection(normalizationContext: ['groups' => ['review_session:read', 'uuid']]),
+    ]
+)]
 class ReviewSession
 {
     use UuidTrait;
 
     #[ORM\ManyToOne(inversedBy: 'reviewSessions')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['review_session:item'])]
     private ?User $reviewer = null;
 
     #[ORM\ManyToOne(inversedBy: 'reviewSessions')]
+    #[Groups(['review_session:read'])]
     private ?Deck $deck = null;
 
     #[ORM\Column(enumType: ReviewMode::class)]
+    #[Groups(['review_session:item'])]
     private ?ReviewMode $mode = null;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
     #[Gedmo\Timestampable(on: 'create')]
+    #[Groups(['review_session:item'])]
     private ?DateTimeImmutable $started_at = null;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    #[Groups(['review_session:item'])]
     private ?DateTimeImmutable $finished_at = null;
 
     #[ORM\Column(options: ['default' => 0])]
+    #[Groups(['review_session:item'])]
     private ?int $cards_seen = 0;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 5, scale: 2, options: ['default' => '0.00'])]
+    #[Groups(['review_session:item'])]
     private ?float $success_pct = 0.00;
 
     #[ORM\Column(options: ['default' => 0])]
+    #[Groups(['review_session:item'])]
     private ?int $xp_gained = 0;
 
     /**

--- a/src/Entity/ReviewSession.php
+++ b/src/Entity/ReviewSession.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Traits\UuidTrait;
+use App\Enum\ReviewMode;
+use App\Repository\ReviewSessionRepository;
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity(repositoryClass: ReviewSessionRepository::class)]
+#[ApiResource]
+class ReviewSession
+{
+    use UuidTrait;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewSessions')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $reviewer = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reviewSessions')]
+    private ?Deck $deck = null;
+
+    #[ORM\Column(enumType: ReviewMode::class)]
+    private ?ReviewMode $mode = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
+    #[Gedmo\Timestampable(on: 'create')]
+    private ?DateTimeImmutable $started_at = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $finished_at = null;
+
+    #[ORM\Column(options: ['default' => 0])]
+    private ?int $cards_seen = 0;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 5, scale: 2, options: ['default' => '0.00'])]
+    private ?float $success_pct = 0.00;
+
+    #[ORM\Column(options: ['default' => 0])]
+    private ?int $xp_gained = 0;
+
+    /**
+     * @var Collection<int, ReviewEvent>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewEvent::class, mappedBy: 'session', orphanRemoval: true)]
+    private Collection $reviewEvents;
+
+    public function __construct()
+    {
+        $this->reviewEvents = new ArrayCollection();
+    }
+
+    public function getReviewer(): ?User
+    {
+        return $this->reviewer;
+    }
+
+    public function setReviewer(?User $reviewer): static
+    {
+        $this->reviewer = $reviewer;
+
+        return $this;
+    }
+
+    public function getDeck(): ?Deck
+    {
+        return $this->deck;
+    }
+
+    public function setDeck(?Deck $deck): static
+    {
+        $this->deck = $deck;
+
+        return $this;
+    }
+
+    public function getMode(): ?ReviewMode
+    {
+        return $this->mode;
+    }
+
+    public function setMode(ReviewMode $mode): static
+    {
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    public function getStartedAt(): ?DateTimeImmutable
+    {
+        return $this->started_at;
+    }
+
+    public function setStartedAt(DateTimeImmutable $started_at): static
+    {
+        $this->started_at = $started_at;
+
+        return $this;
+    }
+
+    public function getFinishedAt(): ?DateTimeImmutable
+    {
+        return $this->finished_at;
+    }
+
+    public function setFinishedAt(?DateTimeImmutable $finished_at): static
+    {
+        $this->finished_at = $finished_at;
+
+        return $this;
+    }
+
+    public function getCardsSeen(): ?int
+    {
+        return $this->cards_seen;
+    }
+
+    public function setCardsSeen(int $cards_seen): static
+    {
+        $this->cards_seen = $cards_seen;
+
+        return $this;
+    }
+
+    public function getSuccessPct(): ?float
+    {
+        return $this->success_pct;
+    }
+
+    public function setSuccessPct(float $success_pct): static
+    {
+        $this->success_pct = $success_pct;
+
+        return $this;
+    }
+
+    public function getXpGained(): ?int
+    {
+        return $this->xp_gained;
+    }
+
+    public function setXpGained(int $xp_gained): static
+    {
+        $this->xp_gained = $xp_gained;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewEvent>
+     */
+    public function getReviewEvents(): Collection
+    {
+        return $this->reviewEvents;
+    }
+
+    public function addReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if (!$this->reviewEvents->contains($reviewEvent)) {
+            $this->reviewEvents->add($reviewEvent);
+            $reviewEvent->setSession($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if ($this->reviewEvents->removeElement($reviewEvent)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewEvent->getSession() === $this) {
+                $reviewEvent->setSession(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -45,7 +45,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     ];
 
     #[ORM\Column(length: 180)]
-    #[Groups(['deck:item'])]
+    #[Groups(['user:item'])]
     private ?string $email = null;
 
     /**
@@ -120,6 +120,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: ReviewQueue::class, mappedBy: 'owner', orphanRemoval: true)]
     private Collection $reviewQueues;
 
+    /**
+     * @var Collection<int, ReviewSession>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewSession::class, mappedBy: 'reviewer', orphanRemoval: true)]
+    private Collection $reviewSessions;
+
+    /**
+     * @var Collection<int, ReviewEvent>
+     */
+    #[ORM\OneToMany(targetEntity: ReviewEvent::class, mappedBy: 'reviewer', orphanRemoval: true)]
+    private Collection $reviewEvents;
+
     public function __construct()
     {
         $this->userBadges = new ArrayCollection();
@@ -130,6 +142,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->deckComments = new ArrayCollection();
         $this->scoreEvents = new ArrayCollection();
         $this->reviewQueues = new ArrayCollection();
+        $this->reviewSessions = new ArrayCollection();
+        $this->reviewEvents = new ArrayCollection();
     }
 
     public function getEmail(): ?string
@@ -555,6 +569,66 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
             // set the owning side to null (unless already changed)
             if ($reviewQueue->getOwner() === $this) {
                 $reviewQueue->setOwner(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewSession>
+     */
+    public function getReviewSessions(): Collection
+    {
+        return $this->reviewSessions;
+    }
+
+    public function addReviewSession(ReviewSession $reviewSession): static
+    {
+        if (!$this->reviewSessions->contains($reviewSession)) {
+            $this->reviewSessions->add($reviewSession);
+            $reviewSession->setReviewer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewSession(ReviewSession $reviewSession): static
+    {
+        if ($this->reviewSessions->removeElement($reviewSession)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewSession->getReviewer() === $this) {
+                $reviewSession->setReviewer(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, ReviewEvent>
+     */
+    public function getReviewEvents(): Collection
+    {
+        return $this->reviewEvents;
+    }
+
+    public function addReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if (!$this->reviewEvents->contains($reviewEvent)) {
+            $this->reviewEvents->add($reviewEvent);
+            $reviewEvent->setReviewer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReviewEvent(ReviewEvent $reviewEvent): static
+    {
+        if ($this->reviewEvents->removeElement($reviewEvent)) {
+            // set the owning side to null (unless already changed)
+            if ($reviewEvent->getReviewer() === $this) {
+                $reviewEvent->setReviewer(null);
             }
         }
 

--- a/src/Enum/ReviewMode.php
+++ b/src/Enum/ReviewMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum ReviewMode: string
+{
+    case FLASHCARD = 'flashcard';
+    case QCM = 'qcm';
+}

--- a/src/EventSubscriber/ReviewEventSubscriber.php
+++ b/src/EventSubscriber/ReviewEventSubscriber.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use ApiPlatform\Symfony\EventListener\EventPriorities;
+use App\Entity\ReviewEvent;
+use App\Entity\User;
+use App\Repository\ReviewSessionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+readonly class ReviewEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private Security                $security,
+        private ReviewSessionRepository $sessionRepository,
+        private EntityManagerInterface  $entityManager
+    )
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW => [
+                ['processReviewEvent', EventPriorities::PRE_WRITE],
+                ['updateSessionStatistics', EventPriorities::POST_WRITE]
+            ]
+        ];
+    }
+
+    public function processReviewEvent(ViewEvent $event): void
+    {
+        $reviewEvent = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        if (!$reviewEvent instanceof ReviewEvent || Request::METHOD_POST !== $method) {
+            return;
+        }
+
+        // Get the current user and set as reviewer
+        if (!$currentUser = $this->security->getUser()) {
+            throw new LogicException('The user must be logged in to create a review event.');
+        }
+
+        if (!$currentUser instanceof User) {
+            throw new LogicException('The current user must be an instance of User.');
+        }
+
+        $reviewEvent->setReviewer($currentUser);
+
+        $data = json_decode($event->getRequest()->getContent(), true);
+        if (!isset($data['session'])) {
+            throw new LogicException('The session ID must be provided.');
+        }
+
+        // Extract the UUID from the IRI
+        $sessionIri = $data['session'];
+        $sessionId = substr($sessionIri, strrpos($sessionIri, '/') + 1);
+
+        $session = $this->sessionRepository->find($sessionId);
+        if (!$session) {
+            throw new LogicException('The specified session does not exist.');
+        }
+
+        // Verify if the card belongs to the deck of the session
+        $card = $reviewEvent->getCard();
+        $sessionDeck = $session->getDeck();
+
+        if ($sessionDeck && $card && !$sessionDeck->getCards()->contains($card)) {
+            throw new LogicException('The card does not belong to the deck of this session.');
+        }
+    }
+
+    public function updateSessionStatistics(ViewEvent $event): void
+    {
+        $reviewEvent = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        if (!$reviewEvent instanceof ReviewEvent || Request::METHOD_POST !== $method) {
+            return;
+        }
+
+        $session = $reviewEvent->getSession();
+        if (!$session) {
+            return;
+        }
+
+        // Update session statistics
+        $cardsSeen = $session->getCardsSeen() + 1;
+        $session->setCardsSeen($cardsSeen);
+
+        // Calculate new success percentage
+        $totalScore = 0;
+        foreach ($session->getReviewEvents() as $event) {
+            $totalScore += $event->getScore();
+        }
+
+        // Calculate percentage (max score would be 5 points per card)
+        $successPct = ($totalScore / ($cardsSeen * 5)) * 100;
+        $session->setSuccessPct($successPct);
+
+        $this->entityManager->persist($session);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Repository/ReviewEventRepository.php
+++ b/src/Repository/ReviewEventRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReviewEvent;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReviewEvent>
+ */
+class ReviewEventRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReviewEvent::class);
+    }
+
+    //    /**
+    //     * @return ReviewEvent[] Returns an array of ReviewEvent objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('r.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?ReviewEvent
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/src/Repository/ReviewSessionRepository.php
+++ b/src/Repository/ReviewSessionRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReviewSession;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReviewSession>
+ */
+class ReviewSessionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReviewSession::class);
+    }
+
+    //    /**
+    //     * @return ReviewSession[] Returns an array of ReviewSession objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('r.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?ReviewSession
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}


### PR DESCRIPTION
Cette PR ajoute les entités et routes pour `review_session` et `review_event`.

Un utilisateur commence par créer une session via `POST  /api/review_sessions/start` ensuite, au fur et à mesure il update la session en faisant des `POST /api/review_events`.
Finalement la session prend fin sur `/api/review_sessions/{id}/finish`, des points sont attribué à l'utilisateur et les stats de la révision sont recalculés.