### PR TITLE
feature: refresh token

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.4.2",
         "doctrine/orm": "^3.5",
         "gedmo/doctrine-extensions": "^3.20",
+        "gesdinet/jwt-refresh-token-bundle": "^1.5",
         "lexik/jwt-authentication-bundle": "^3.1.1",
         "nelmio/cors-bundle": "^2.5",
         "nelmio/security-bundle": "^3.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d18eca3a5270aca2943a004cf4001167",
+    "content-hash": "eea19b88be2f5147b0af1ae9cb0f5f07",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2601,6 +2601,86 @@
                 }
             ],
             "time": "2025-04-04T17:19:27+00:00"
+        },
+        {
+            "name": "gesdinet/jwt-refresh-token-bundle",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markitosgv/JWTRefreshTokenBundle.git",
+                "reference": "8706b0d8dcb26610358ba3328ec412315b55c3cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markitosgv/JWTRefreshTokenBundle/zipball/8706b0d8dcb26610358ba3328ec412315b55c3cd",
+                "reference": "8706b0d8dcb26610358ba3328ec412315b55c3cd",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^1.3.3|^2.0|^3.0|^4.0",
+                "lexik/jwt-authentication-bundle": "^2.0|^3.0",
+                "php": ">=7.4",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/deprecation-contracts": "^2.1|^3.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/security-bundle": "^5.4|^6.0|^7.0",
+                "symfony/security-core": "^5.4|^6.0|^7.0",
+                "symfony/security-http": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "doctrine/mongodb-odm": "<2.2",
+                "doctrine/orm": "<2.7"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13|^2.0",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/mongodb-odm": "^2.2",
+                "doctrine/orm": "^2.7|^3.0",
+                "matthiasnoback/symfony-config-test": "^4.2|^5.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^4.2|^5.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/security-guard": "^5.4"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Gesdinet\\JWTRefreshTokenBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcos Gómez Vilches",
+                    "email": "marcos@gesdinet.com"
+                }
+            ],
+            "description": "Implements a refresh token system over Json Web Tokens in Symfony",
+            "keywords": [
+                "jwt refresh token bundle symfony json web"
+            ],
+            "support": {
+                "issues": "https://github.com/markitosgv/JWTRefreshTokenBundle/issues",
+                "source": "https://github.com/markitosgv/JWTRefreshTokenBundle/tree/v1.5.0"
+            },
+            "time": "2025-06-24T13:08:37+00:00"
         },
         {
             "name": "jms/metadata",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -13,4 +13,5 @@ return [
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
+    Gesdinet\JWTRefreshTokenBundle\GesdinetJWTRefreshTokenBundle::class => ['all' => true],
 ];

--- a/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -1,0 +1,5 @@
+gesdinet_jwt_refresh_token:
+    user_identity_field: email
+    refresh_token_class: App\Entity\RefreshToken
+    ttl: 2592000
+    single_use: true

--- a/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -3,3 +3,11 @@ gesdinet_jwt_refresh_token:
     refresh_token_class: App\Entity\RefreshToken
     ttl: 2592000
     single_use: true
+    return_expiration: true
+    cookie:
+      enabled: true
+      same_site: lax
+      path: /api/token/refresh
+      http_only: true
+      secure: true
+      remove_token_from_body: false

--- a/config/packages/lexik_jwt_authentication.yaml
+++ b/config/packages/lexik_jwt_authentication.yaml
@@ -5,6 +5,6 @@ lexik_jwt_authentication:
     token_ttl: 3600
     user_id_claim: email
     api_platform:
-        check_path: /api/login_check
-        username_path: username
+        check_path: /api/login
+        username_path: email
         password_path: security.credentials.password

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,6 +26,8 @@ security:
             refresh_jwt:
                 check_path: /api/token/refresh
                 provider: app_user_provider
+            logout:
+                path: api_token_invalidate
         main:
             stateless: true
             lazy: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -13,25 +13,19 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
-        login:
-            pattern: ^/api/login
-            stateless: true
-            json_login:
-                check_path: /api/login_check
-                username_path: email
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
         api:
             pattern: ^/api
             stateless: true
             entry_point: jwt
             json_login:
                 check_path: /api/login
+                username_path: email
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
             jwt: ~
             refresh_jwt:
                 check_path: /api/token/refresh
+                provider: app_user_provider
         main:
             stateless: true
             lazy: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -24,7 +24,14 @@ security:
         api:
             pattern: ^/api
             stateless: true
+            entry_point: jwt
+            json_login:
+                check_path: /api/login
+                success_handler: lexik_jwt_authentication.handler.authentication_success
+                failure_handler: lexik_jwt_authentication.handler.authentication_failure
             jwt: ~
+            refresh_jwt:
+                check_path: /api/token/refresh
         main:
             stateless: true
             lazy: true
@@ -46,6 +53,7 @@ security:
         - { path: ^/api/ping, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: PUBLIC_ACCESS }
         - { path: ^/api/decks?mine=1, roles: ROLE_USER }
+        - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
 

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -6,3 +6,6 @@ controllers:
 
 api_login_check:
     path: /api/login_check
+
+api_refresh_token:
+    path: /api/token/refresh

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -5,7 +5,7 @@ controllers:
     type: attribute
 
 api_login_check:
-    path: /api/login_check
+    path: /api/login
 
 api_refresh_token:
     path: /api/token/refresh

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -9,3 +9,6 @@ api_login_check:
 
 api_refresh_token:
     path: /api/token/refresh
+
+api_token_invalidate:
+    path: /api/logout

--- a/config/routes/api_login_check.yaml
+++ b/config/routes/api_login_check.yaml
@@ -1,2 +1,2 @@
 api_login_check:
-  path: /api/login_check
+  path: /api/login

--- a/config/routes/gesdinet_jwt_refresh_token.yaml
+++ b/config/routes/gesdinet_jwt_refresh_token.yaml
@@ -1,0 +1,2 @@
+gesdinet_jwt_refresh_token:
+    path: /api/token/refresh

--- a/migrations/Version20250903111124.php
+++ b/migrations/Version20250903111124.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250903111124 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE refresh_tokens (id SERIAL NOT NULL, refresh_token VARCHAR(128) NOT NULL, username VARCHAR(255) NOT NULL, valid TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9BACE7E1C74F2195 ON refresh_tokens (refresh_token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP TABLE refresh_tokens');
+    }
+}

--- a/src/Entity/RefreshToken.php
+++ b/src/Entity/RefreshToken.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'refresh_tokens')]
+class RefreshToken extends BaseRefreshToken
+{
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -49,6 +49,20 @@
             "./migrations/.gitignore"
         ]
     },
+    "gesdinet/jwt-refresh-token-bundle": {
+        "version": "1.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "2390b4ed5c195e0b3f6dea45221f3b7c0af523a0"
+        },
+        "files": [
+            "config/packages/gesdinet_jwt_refresh_token.yaml",
+            "config/routes/gesdinet_jwt_refresh_token.yaml",
+            "src/Entity/RefreshToken.php"
+        ]
+    },
     "lexik/jwt-authentication-bundle": {
         "version": "3.1",
         "recipe": {


### PR DESCRIPTION
Cette PR implémente un flux de refresh token pour renouveler automatiquement le JWT d’accès sans forcer l’utilisateur à se reconnecter.

Un utilisateur récupère un token et un refresh token qui sera mis dans un cookie en saisissant ses identifiants via <code>POST /api/login</code> et peut renouveler son token avec son refresh token dans <code>POST /api/token/refresh</code>.
Enfin, il peut aussi révoquer son refresh token dans <code>POST /api/logout</code>.
