### PR TITLE
feature: fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,10 @@ sf: ## List all Symfony commands or pass the parameter "c=" to run a given comma
 
 cc: c=c:c ## Clear the cache
 cc: sf
+
+## —— Database reset and data seeding 🐘 ———————————————————————————————————————————
+seed:
+	php bin/console doctrine:database:drop --force --if-exists
+	php bin/console doctrine:database:create
+	php bin/console doctrine:migrations:migrate --no-interaction
+	php bin/console doctrine:fixtures:load --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,8 @@
         }
     },
     "require-dev": {
+        "doctrine/doctrine-fixtures-bundle": "^4.1",
+        "fakerphp/faker": "^1.24",
         "symfony/maker-bundle": "^1.64"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea902b8013df38b1466418db62cc362d",
+    "content-hash": "305858045bc7127058c05b6031816290",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -9518,6 +9518,238 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/data-fixtures",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "f161e20f04ba5440a09330e156b40f04dd70d47f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/f161e20f04ba5440a09330e156b40f04dd70d47f",
+                "reference": "f161e20f04ba5440a09330e156b40f04dd70d47f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^1.1 || ^2 || ^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.5 || >=5",
+                "doctrine/orm": "<2.14 || >=4",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "doctrine/dbal": "^3.5 || ^4",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.14 || ^3",
+                "ext-sqlite3": "*",
+                "fig/log-test": "^1",
+                "phpstan/phpstan": "2.1.17",
+                "phpunit/phpunit": "10.5.45",
+                "symfony/cache": "^6.4 || ^7",
+                "symfony/var-exporter": "^6.4 || ^7"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-08T17:48:20+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "a06db6b81ff20a2980bf92063d80c013bb8b4b7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/a06db6b81ff20a2980bf92063d80c013bb8b4b7c",
+                "reference": "a06db6b81ff20a2980bf92063d80c013bb8b4b7c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^2.0",
+                "doctrine/doctrine-bundle": "^2.2",
+                "doctrine/orm": "^2.14.0 || ^3.0",
+                "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^2 || ^3",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/console": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9",
+                "symfony/http-kernel": "^6.4 || ^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "< 3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "13.0.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpunit/phpunit": "^10.5.38 || 11.4.14"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-26T10:56:26+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v5.5.0",
             "source": {
@@ -9732,7 +9964,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -9740,6 +9972,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -14,4 +14,5 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
     Gesdinet\JWTRefreshTokenBundle\GesdinetJWTRefreshTokenBundle::class => ['all' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class AppFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // $product = new Product();
+        // $manager->persist($product);
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures;
 
+use App\DataFixtures\CardFixtures;
 use App\DataFixtures\DeckFixtures;
 use App\DataFixtures\TagFixtures;
 use App\DataFixtures\UserFixtures;
@@ -26,6 +27,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             UserFixtures::class,
             TagFixtures::class,
             DeckFixtures::class,
+            CardFixtures::class,
         ];
     }
 }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures;
 
 use App\DataFixtures\CardFixtures;
 use App\DataFixtures\DeckFixtures;
+use App\DataFixtures\RatingFixtures;
 use App\DataFixtures\TagFixtures;
 use App\DataFixtures\UserFixtures;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -28,6 +29,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             TagFixtures::class,
             DeckFixtures::class,
             CardFixtures::class,
+            RatingFixtures::class,
         ];
     }
 }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures;
 
+use App\DataFixtures\TagFixtures;
 use App\DataFixtures\UserFixtures;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
@@ -22,6 +23,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
     {
         return [
             UserFixtures::class,
+            TagFixtures::class,
         ];
     }
 }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures;
 
+use App\DataFixtures\DeckFixtures;
 use App\DataFixtures\TagFixtures;
 use App\DataFixtures\UserFixtures;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -24,6 +25,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         return [
             UserFixtures::class,
             TagFixtures::class,
+            DeckFixtures::class,
         ];
     }
 }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -2,10 +2,13 @@
 
 namespace App\DataFixtures;
 
+use App\DataFixtures\UserFixtures;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class AppFixtures extends Fixture
+
+class AppFixtures extends Fixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {
@@ -13,5 +16,12 @@ class AppFixtures extends Fixture
         // $manager->persist($product);
 
         $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            UserFixtures::class,
+        ];
     }
 }

--- a/src/DataFixtures/CardFixtures.php
+++ b/src/DataFixtures/CardFixtures.php
@@ -30,6 +30,7 @@ class CardFixtures extends Fixture
         $cardCount = 0;
         $cardSideCount = 0;
         $cardBlockCount = 0;
+        $sides = [CardSides::FRONT, CardSides::BACK];
 
         foreach ($decks as $deck) {
             for ($i = 0; $i < 20; $i++) {
@@ -38,40 +39,25 @@ class CardFixtures extends Fixture
                 $deck->setCardCount($deck->getCardCount() + 1);
                 $card->setPosition($i);
 
-                $cardSideFront = new CardSide();
-                $cardSideFront->setCard($card);
-                $cardSideFront->setSide(CardSides::FRONT);
+                foreach ($sides as $side) {
+                    $cardSide = new CardSide();
+                    $cardSide->setCard($card);
+                    $cardSide->setSide($side);
 
-                $this->addReference(self::CARD_SIDE_REFERENCE . '_' . $cardSideCount, $cardSideFront);
-                $cardSideCount++;
+                    $manager->persist($cardSide);
+                    $this->addReference(self::CARD_SIDE_REFERENCE . '_' . $cardSideCount, $cardSide);
+                    $cardSideCount++;
 
-                $cardBlockFront = new CardBlock();
-                $cardBlockFront->setCardSide($cardSideFront);
-                $cardBlockFront->setContent($this->faker->sentence(10));
+                    $cardBlock = new CardBlock();
+                    $cardBlock->setCardSide($cardSide);
+                    $cardBlock->setContent($this->faker->sentence(10));
 
-                $this->addReference(self::CARD_BLOCK_REFERENCE . '_' . $cardBlockCount, $cardBlockFront);
-                $cardBlockCount++;
-
-                $cardSideBack = new CardSide();
-                $cardSideBack->setCard($card);
-                $cardSideBack->setSide(CardSides::BACK);
-
-                $this->addReference(self::CARD_SIDE_REFERENCE . '_' . $cardSideCount, $cardSideBack);
-                $cardSideCount++;
-
-                $cardBlockBack = new CardBlock();
-                $cardBlockBack->setCardSide($cardSideBack);
-                $cardBlockBack->setContent($this->faker->sentence(10));
-
-                $this->addReference(self::CARD_BLOCK_REFERENCE . '_' . $cardBlockCount, $cardBlockBack);
-                $cardBlockCount++;
+                    $manager->persist($cardBlock);
+                    $this->addReference(self::CARD_BLOCK_REFERENCE . '_' . $cardBlockCount, $cardBlock);
+                    $cardBlockCount++;
+                }
 
                 $manager->persist($card);
-                $manager->persist($cardSideFront);
-                $manager->persist($cardBlockFront);
-                $manager->persist($cardSideBack);
-                $manager->persist($cardBlockBack);
-
                 $this->addReference(self::CARD_REFERENCE . '_' . $cardCount, $card);
                 $cardCount++;
             }

--- a/src/DataFixtures/CardFixtures.php
+++ b/src/DataFixtures/CardFixtures.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\Card;
+use App\Entity\CardBlock;
+use App\Entity\CardSide;
+use App\Enum\CardSides;
+use App\Repository\DeckRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory;
+
+class CardFixtures extends Fixture
+{
+    protected $faker;
+    private const CARD_REFERENCE = 'card';
+    private const CARD_SIDE_REFERENCE = 'card_side';
+    private const CARD_BLOCK_REFERENCE = 'card_block';
+
+    public function __construct(DeckRepository $deckRepository)
+    {
+        $this->faker = Factory::create();
+        $this->deckRepository = $deckRepository;
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $decks = $this->deckRepository->findAll();
+        $cardCount = 0;
+        $cardSideCount = 0;
+        $cardBlockCount = 0;
+
+        foreach ($decks as $deck) {
+            for ($i = 0; $i < 20; $i++) {
+                $card = new Card();
+                $card->setDeck($deck);
+                $deck->setCardCount($deck->getCardCount() + 1);
+                $card->setPosition($i);
+
+                $cardSideFront = new CardSide();
+                $cardSideFront->setCard($card);
+                $cardSideFront->setSide(CardSides::FRONT);
+
+                $this->addReference(self::CARD_SIDE_REFERENCE . '_' . $cardSideCount, $cardSideFront);
+                $cardSideCount++;
+
+                $cardBlockFront = new CardBlock();
+                $cardBlockFront->setCardSide($cardSideFront);
+                $cardBlockFront->setContent($this->faker->sentence(10));
+
+                $this->addReference(self::CARD_BLOCK_REFERENCE . '_' . $cardBlockCount, $cardBlockFront);
+                $cardBlockCount++;
+
+                $cardSideBack = new CardSide();
+                $cardSideBack->setCard($card);
+                $cardSideBack->setSide(CardSides::BACK);
+
+                $this->addReference(self::CARD_SIDE_REFERENCE . '_' . $cardSideCount, $cardSideBack);
+                $cardSideCount++;
+
+                $cardBlockBack = new CardBlock();
+                $cardBlockBack->setCardSide($cardSideBack);
+                $cardBlockBack->setContent($this->faker->sentence(10));
+
+                $this->addReference(self::CARD_BLOCK_REFERENCE . '_' . $cardBlockCount, $cardBlockBack);
+                $cardBlockCount++;
+
+                $manager->persist($card);
+                $manager->persist($cardSideFront);
+                $manager->persist($cardBlockFront);
+                $manager->persist($cardSideBack);
+                $manager->persist($cardBlockBack);
+
+                $this->addReference(self::CARD_REFERENCE . '_' . $cardCount, $card);
+                $cardCount++;
+            }
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/DeckFixtures.php
+++ b/src/DataFixtures/DeckFixtures.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\Deck;
+use App\Entity\Tag;
+use App\Enum\CountryCodeAlpha2;
+use App\Enum\DeckStatus;
+use App\Enum\DeckVisibility;
+use App\Repository\UserRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory;
+
+class DeckFixtures extends Fixture
+{
+    protected $faker;
+    private const DECK_REFERENCE = 'deck';
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->faker = Factory::create();
+        $this->userRepository = $userRepository;
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = $this->userRepository->findAll();
+        $deckCount = 0;
+       
+        foreach ($users as $user) {
+            for ($i = 0; $i < 3; $i++) {
+                $deck = new Deck();
+                $deck->setOwner($user);
+                $deck->setTitle($this->faker->sentence(3));
+                $deck->setDescription($this->faker->paragraph());
+                $deck->setLanguage(CountryCodeAlpha2::France);
+                $deck->setVisibility(DeckVisibility::PUBLIC);
+                $status = rand(0, 100);
+                $numberTags = rand(1, 3);
+
+                if ($status < 80) {
+                    $deck->setStatus(DeckStatus::PUBLISHED);
+                } else {
+                    $deck->setStatus(DeckStatus::DRAFT);
+                }
+
+                for ($j = 0; $j < $numberTags; $j++) {
+                    $tag = $this->getReference('tag_' . rand(0, 11), Tag::class);
+                    $deck->addTag($tag);
+                }
+
+                $manager->persist($deck);
+                $this->addReference(self::DECK_REFERENCE . '_' . $deckCount, $deck);
+                $deckCount++;
+            }
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/RatingFixtures.php
+++ b/src/DataFixtures/RatingFixtures.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\DeckRating;
+use App\Repository\DeckRepository;
+use App\Repository\UserRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory;
+
+class RatingFixtures extends Fixture
+{
+    protected $faker;
+    private const RATING_REFERENCE = 'rating';
+
+    public function __construct(UserRepository $userRepository, DeckRepository $deckRepository)
+    {
+        $this->faker = Factory::create();
+        $this->userRepository = $userRepository;
+        $this->deckRepository = $deckRepository;
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = $this->userRepository->findAll();
+        $decks = $this->deckRepository->findAll();
+        $rated = []; // To track which user has rated which deck
+
+        for ($i = 0; $i < 50; $i++) {
+            $rater = $users[array_rand($users)];
+            $deck = $decks[array_rand($decks)];
+            $key = $rater->getId() . '-' . $deck->getId();
+
+            // The user has already rated this deck
+            while (isset($rated[$key])) {
+                $deck = $decks[array_rand($decks)]; // Pick another deck
+                $key = $rater->getId() . '-' . $deck->getId();
+            }
+
+            $rated[$key] = true; // Mark this user-deck pair as rated
+
+            $rating = new DeckRating();
+            $rating->setRater($rater);
+            $rating->setDeck($deck);
+            $deck->setRatingCount($deck->getRatingCount() + 1);
+            $rating->setRating(rand(1, 5));
+
+            $manager->persist($rating);
+            $this->addReference(self::RATING_REFERENCE . '_' . $i, $rating);
+        }
+
+        $manager->flush();
+
+        foreach ($decks as $deck) {
+            $ratings = $deck->getDeckRatings();
+
+            if (count($ratings) > 0) {
+                $totalRating = 0;
+
+                foreach ($ratings as $rating) {
+                    $totalRating += $rating->getRating();
+                }
+
+                $averageRating = $totalRating / count($ratings);
+                $deck->setRatingAvg($averageRating);
+            } else {
+                $deck->setRatingAvg(0);
+            }
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/TagFixtures.php
+++ b/src/DataFixtures/TagFixtures.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\Tag;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory;
+
+class TagFixtures extends Fixture
+{
+    protected $faker;
+    private const TAG_REFERENCE = 'tag';
+    private $parentsTags = ['Maths', 'Langues', 'Science'];
+
+    public function __construct()
+    {
+        $this->faker = Factory::create();
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        for ($i = 0; $i < count($this->parentsTags); $i++) {
+            $tag = new Tag();
+            $tag->setName($this->parentsTags[$i]);
+            $tag->setSlug(strtolower($this->parentsTags[$i]));
+            $tag->setCreatedAt(\DateTimeImmutable::createFromMutable($this->faker->datetime()));
+            $manager->persist($tag);
+
+            $this->addReference(self::TAG_REFERENCE . '_' . $i, $tag);
+        }
+
+        $manager->flush();
+
+        for ($i = 3; $i < 12; $i++) {
+            $tag = new Tag();
+            $tag->setName($this->faker->word());
+            $tag->setSlug(strtolower($this->faker->word()));
+            $tag->setCreatedAt(\DateTimeImmutable::createFromMutable($this->faker->datetime()));
+            $parentTag = $this->getReference(self::TAG_REFERENCE . '_' . $this->faker->numberBetween(0, 2), Tag::class);
+            $tag->setParentTag($parentTag);
+            $manager->persist($tag);
+
+            $this->addReference(self::TAG_REFERENCE . '_' . $i, $tag);
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -25,7 +25,7 @@ class UserFixtures extends Fixture
         for ($i = 0; $i < 10; $i++) {
             $user = new User();
             $user->setEmail($this->faker->email());
-            $password = $this->passwordHasher->hashPassword($user, $this->faker->password());
+            $password = $this->passwordHasher->hashPassword($user, 'password');
             $user->setPassword($password);
             $user->setUserName($this->faker->userName());
             $user->setRoles(['ROLE_USER']);

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Faker\Factory;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserFixtures extends Fixture
+{
+    protected UserPasswordHasherInterface $passwordHasher;
+    protected $faker;
+    private const USER_REFERENCE = 'user';
+
+    public function __construct(UserPasswordHasherInterface $passwordHasher)
+    {
+        $this->passwordHasher = $passwordHasher;
+        $this->faker = Factory::create();
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $user = new User();
+            $user->setEmail($this->faker->email());
+            $password = $this->passwordHasher->hashPassword($user, $this->faker->password());
+            $user->setPassword($password);
+            $user->setUserName($this->faker->userName());
+            $user->setRoles(['ROLE_USER']);
+            $user->setCreatedAt(\DateTimeImmutable::createFromMutable($this->faker->datetime()));
+            $manager->persist($user);
+            $manager->flush();
+
+            $this->addReference(self::USER_REFERENCE . '_' . $i, $user);
+        }
+    }
+}

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -39,7 +39,6 @@ class Tag
 
     public function __construct()
     {
-        $this->parent_tag = new ArrayCollection();
         $this->decks = new ArrayCollection();
     }
 
@@ -75,28 +74,6 @@ class Tag
     public function setDescription(?string $description): static
     {
         $this->description = $description;
-
-        return $this;
-    }
-
-    public function addParentTag(self $parentTag): static
-    {
-        if (!$this->parent_tag->contains($parentTag)) {
-            $this->parent_tag->add($parentTag);
-            $parentTag->setParentTag($this);
-        }
-
-        return $this;
-    }
-
-    public function removeParentTag(self $parentTag): static
-    {
-        if ($this->parent_tag->removeElement($parentTag)) {
-            // set the owning side to null (unless already changed)
-            if ($parentTag->getParentTag() === $this) {
-                $parentTag->setParentTag(null);
-            }
-        }
 
         return $this;
     }

--- a/symfony.lock
+++ b/symfony.lock
@@ -36,6 +36,18 @@
             "./src/Repository/.gitignore"
         ]
     },
+    "doctrine/doctrine-fixtures-bundle": {
+        "version": "4.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "1f5514cfa15b947298df4d771e694e578d4c204d"
+        },
+        "files": [
+            "./src/DataFixtures/AppFixtures.php"
+        ]
+    },
     "doctrine/doctrine-migrations-bundle": {
         "version": "3.4",
         "recipe": {


### PR DESCRIPTION
Cette PR met en place les fixtures qui peuvent être appelées grâce à la commande <code>php bin/console doctrine:fixtures:load</code> en dev.

Une cible 'seed' est rajoutée dans <code>MakeFile</code> qui permet de supprimer la base de données, de la recréer, d'effectuer les migrations et d'appeler les fixtures.