### PR TITLE
feature: import .txt files

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,7 @@ security:
         - { path: ^/api, roles: PUBLIC_ACCESS }
         - { path: ^/api/decks?mine=1, roles: ROLE_USER }
         - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
+        - { path: ^/api/import/text, roles: ROLE_USER }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
 

--- a/src/Controller/ImportTxtController.php
+++ b/src/Controller/ImportTxtController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class ImportTxtController extends AbstractController
+{
+    #[Route('api/import/text', name: 'api_import_text', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function importText(Request $request): JsonResponse
+    {
+        $cards = [];
+        $cardCount = 0;
+        $front = '';
+        $back = '';
+        $file = $request->files->get('file');
+        $pathName = $file->getPathname();
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $fileType = finfo_file($finfo, $pathName);
+        $fileSize = $file->getSize();
+        finfo_close($finfo);
+
+        if ($fileType !== 'text/plain' || $fileSize > 1048576) {
+            return $this->json(['message' => 'Invalid file type or size'], 422);
+        }
+
+        if ($file = fopen($pathName, "r")) {
+            while(!feof($file)) {
+                $line = fgets($file);
+                $firstWord = strtok($line, " ");
+
+                switch ($firstWord) {
+                    case 'Carte': // New card
+                        $cardCount++;
+                        break;
+                    case 'front:': // Front side
+                        $front = trim(substr($line, 7, strlen($line)));
+                        break;
+                    case 'back:': // Back side
+                        $back = trim(substr($line, 6, strlen($line)));
+
+                        $cards[] = ['front' => $front, 'back' => $back];
+                        $front = '';
+                        $back = '';
+                        break;
+                    default: // Skip other lines
+                }
+            }
+
+            fclose($file);
+        }
+
+        return $this->json([
+            'cards' => $cards,
+            'cardCount' => $cardCount
+        ]);
+    }
+}


### PR DESCRIPTION
Cette PR met en place l'importation de fichiers .txt pour le contenu d'un deck. 
L'utilisateur envoie un fichier .txt dans <code>POST api/import/text</code> qui lit le fichier et renvoie le résultat suivant :
<code>{
     "cards": [
    {
      "front": "Qu’est-ce que π ?",
      "back":  "π est le rapport circonférence / diamètre."
    },
    {
      "front": "Loi de Newton",
      "back":  "F = m · a"
    }
  ],
  "cardCount": 2
  }</code>