### PR TITLE
feature: import .json files

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -17,7 +17,7 @@ class ImportController extends AbstractController
     public function importText(Request $request): JsonResponse
     {
         $cards = [];
-        $cardCount = 0;
+        $cardCount = 1;
         $file = $request->files->get('file');
         $pathName = $file->getPathname();
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
@@ -25,34 +25,68 @@ class ImportController extends AbstractController
         $fileSize = $file->getSize();
         finfo_close($finfo);
 
-        if ($fileType !== 'text/plain') {
+        if ($fileType != 'text/plain') {
             return $this->json(['message' => 'Invalid file type'], 422);
         } elseif ($fileSize > 1048576) {
             return $this->json(['message' => 'File size exceeds limit'], 413);
         }
 
         if ($file = fopen($pathName, "r")) {
+            $currentCard = ['front' => '', 'back' => ''];
+            $hasCardHeader = false;
+
             while(!feof($file)) {
                 $line = fgets($file);
-                $firstWord = strtok($line, " ");
 
-                switch ($firstWord) {
-                    case 'Carte': // New card
-                        $cardCount++;
-                        break;
-                    case 'front:': // Front side
-                        $front = trim(substr($line, 6, strlen($line)));
-                        break;
-                    case 'back:': // Back side
-                        $back = trim(substr($line, 5, strlen($line)));
-                        $cards[] = ['front' => $front, 'back' => $back];
-                        break;
-                    default: // Skip other lines
+                if (str_starts_with($line, 'Carte')) {
+                    if ($hasCardHeader) { // Either the front or back is missing
+                        if (empty($currentCard['front'])) {
+                            return $this->json(['message' => 'Missing front for Card '.$cardCount], 422);
+                        } elseif (empty($currentCard['back'])) {
+                            return $this->json(['message' => 'Missing back for Card '.$cardCount], 422);
+                        }
+                    }
+
+                    $hasCardHeader = true;
+                } elseif (str_starts_with($line, 'front:')) { // Front side
+                    if (!$hasCardHeader) {
+                        fclose($file);
+                        return $this->json(['message' => 'Missing header for Card '.$cardCount], 422);
+                    }
+
+                    $currentCard['front'] = trim(substr($line, 6));
+                } elseif (str_starts_with($line, 'back:')) { // Back side
+                    if (!$hasCardHeader) {
+                        fclose($file);
+                        return $this->json(['message' => 'Missing header for Card '.$cardCount], 422);
+                    }
+
+                    $currentCard['back'] = trim(substr($line, 5));
+
+                    if (empty($currentCard['front'])) {
+                        fclose($file);
+                        return $this->json(['message' => 'Missing front for Card '.$cardCount], 422);
+                    }
+
+                    $cards[] = $currentCard;
+                    $cardCount++;
+                    $currentCard = ['front' => '', 'back' => ''];
+                    $hasCardHeader = false;
                 }
             }
 
             fclose($file);
+
+            if ($hasCardHeader) { // Either the front or back for the last card is missing
+                if (empty($currentCard['front'])) {
+                    return $this->json(['message' => 'Missing front for Card '.$cardCount], 422);
+                } elseif (empty($currentCard['back'])) {
+                    return $this->json(['message' => 'Missing back for Card '.$cardCount], 422);
+                }
+            }
         }
+
+        $cardCount--;
 
         return $this->json([
             'cards' => $cards,
@@ -73,7 +107,7 @@ class ImportController extends AbstractController
         $fileSize = $file->getSize();
         finfo_close($finfo);
 
-        if ($fileType !== 'text/plain' && $fileType !== 'text/csv') {
+        if ($fileType != 'text/plain' && $fileType != 'text/csv') {
             return $this->json(['message' => 'Invalid file type'], 422);
         } elseif ($fileSize > 1048576) {
             return $this->json(['message' => 'File size exceeds limit'], 413);
@@ -93,6 +127,13 @@ class ImportController extends AbstractController
             $cardCount++;
             $front = trim($row['front']);
             $back = trim($row['back']);
+
+            if (empty($front)) {
+                return $this->json(['message' => 'Missing front for Card '.$cardCount], 422);
+            } elseif (empty($back)) {
+                return $this->json(['message' => 'Missing back for Card '.$cardCount], 422);
+            }
+
             $cards[] = ['front' => $front, 'back' => $back];
         }
 
@@ -115,7 +156,7 @@ class ImportController extends AbstractController
         $fileSize = $file->getSize();
         finfo_close($finfo);
 
-        if ($fileType !== 'text/plain' && $fileType !== 'text/markdown') {
+        if ($fileType != 'text/plain' && $fileType != 'text/markdown') {
             return $this->json(['message' => 'Invalid file type'], 422);
         } elseif ($fileSize > 1048576) {
             return $this->json(['message' => 'File size exceeds limit'], 413);
@@ -131,7 +172,7 @@ class ImportController extends AbstractController
                 if (str_starts_with($line, '## ')) { // New card
                     if (!empty($front) && empty($back)) { // Missing back side for previous card
                         fclose($file);
-                        return $this->json(['message' => 'Incomplete card: missing back side or separator'], 422);
+                        return $this->json(['message' => 'Card '.$cardCount.' incomplete: missing back side or separator'], 422);
                     }
 
                     $cardCount++;
@@ -141,10 +182,10 @@ class ImportController extends AbstractController
 
                     if (empty($front)) { // Missing front side for current card
                         fclose($file);
-                        return $this->json(['message' => 'Incomplete card: missing front side or header'], 422);
+                        return $this->json(['message' => 'Card '.$cardCount.' incomplete: missing front side or header'], 422);
                     } elseif (empty($back)) { // Missing back side for current card
                         fclose($file);
-                        return $this->json(['message' => 'Incomplete card: missing back side or separator'], 422);
+                        return $this->json(['message' => 'Card '.$cardCount.' incomplete: missing back side or separator'], 422);
                     }
 
                     $cards[] = ['front' => $front, 'back' => $back];
@@ -156,7 +197,7 @@ class ImportController extends AbstractController
             fclose($file);
 
             if (!empty($front) && empty($back)) { // Missing back side for last card
-                return $this->json(['message' => 'Incomplete card: missing back side or separator'], 422);
+                return $this->json(['message' => 'Card '.$cardCount.' incomplete: missing back side or separator'], 422);
             }
         }
 

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -169,4 +169,49 @@ class ImportController extends AbstractController
             'cardCount' => $cardCount
         ]);
     }
+
+    #[Route('api/import/json', name: 'api_import_json', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function importJson(Request $request): JsonResponse
+    {
+        $cardCount = 0;
+        $file = $request->files->get('file');
+        $pathName = $file->getPathname();
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $fileType = finfo_file($finfo, $pathName);
+        $fileSize = $file->getSize();
+        finfo_close($finfo);
+
+        if ($fileType != 'text/plain' && $fileType != 'application/json' && $fileType != 'text/json') {
+            return $this->json(['message' => 'Invalid file type'], 422);
+        } elseif ($fileSize > 1048576) {
+            return $this->json(['message' => 'File size exceeds limit'], 413);
+        }
+
+        $jsonContent = file_get_contents($pathName);
+        $data = json_decode($jsonContent);
+
+        if (json_last_error() != JSON_ERROR_NONE) {
+            return $this->json(['message' => 'Invalid JSON format'], 422);
+        } elseif (gettype($data) != 'array') {
+            return $this->json(['message' => 'Invalid JSON structure'], 422);
+        }
+
+        foreach ($data as $item) {
+            $cardCount++;
+
+            if (gettype($item) != 'object') {
+                return $this->json(['message' => 'Invalid structure for Card '.$cardCount], 422);
+            } elseif (!property_exists($item, 'front')) {
+                return $this->json(['message' => 'Missing front for Card '.$cardCount], 422);
+            } elseif (!property_exists($item, 'back')) {
+                return $this->json(['message' => 'Missing back for Card '.$cardCount], 422);
+            }
+        }
+
+        return $this->json([
+            'cards' => $data,
+            'cardCount' => count($data)
+        ]);
+    }
 }


### PR DESCRIPTION
Cette PR met en place l'importation de fichiers .json pour le contenu d'un deck. 
L'utilisateur dispose d'un fichier .json structuré de la manière suivante : 
```json
[
  { "front": "Qu’est-ce que π ?", "back": "π est le rapport circonférence / diamètre." },
  { "front": "Loi de Newton", "back": "F = m × a" }
]
```

 Ce fichier est envoyé dans <code>POST api/import/json</code> qui le lit et renvoie le résultat suivant :
```
{
   "cards": [
      {
         "front": "Qu’est-ce que π ?", 
         "back": "π est le rapport…"
      },
      { 
         "front": "Loi de Newton",
         "back": "F = m · a"
      }
   ],
   "cardCount": 2
}
```