### PR TITLE
feature: import .pdf files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "phpoffice/phpword": "^1.4",
         "phpstan/phpdoc-parser": "^2.1",
         "runtime/frankenphp-symfony": "^0.2.0",
+        "smalot/pdfparser": "^2.12",
         "stof/doctrine-extensions-bundle": "^1.14",
         "symfony/asset": "7.3.*",
         "symfony/console": "7.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44840f0241e972bc4b1c2814e35aa6fe",
+    "content-hash": "41dd37d0564fb86e9b4baf0f5604c680",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -5263,6 +5263,57 @@
                 }
             ],
             "time": "2023-12-12T12:06:11+00:00"
+        },
+        {
+            "name": "smalot/pdfparser",
+            "version": "v2.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smalot/pdfparser.git",
+                "reference": "98d31ba34ef5b5a98897ef4b6c3925d502ea53b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smalot/pdfparser/zipball/98d31ba34ef5b5a98897ef4b6c3925d502ea53b1",
+                "reference": "98d31ba34ef5b5a98897ef4b6c3925d502ea53b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-zlib": "*",
+                "php": ">=7.1",
+                "symfony/polyfill-mbstring": "^1.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Smalot\\PdfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastien MALOT",
+                    "email": "sebastien@malot.fr"
+                }
+            ],
+            "description": "Pdf parser library. Can read and extract information from pdf file.",
+            "homepage": "https://www.pdfparser.org",
+            "keywords": [
+                "extract",
+                "parse",
+                "parser",
+                "pdf",
+                "text"
+            ],
+            "support": {
+                "issues": "https://github.com/smalot/pdfparser/issues",
+                "source": "https://github.com/smalot/pdfparser/tree/v2.12.1"
+            },
+            "time": "2025-07-31T06:19:56+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",

--- a/src/Controller/ImportPdfController.php
+++ b/src/Controller/ImportPdfController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\ImportResponse;
+use App\Service\PdfImportService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class ImportPdfController extends AbstractController
+{
+    public function __construct(
+        private PdfImportService $pdfImportService
+    ) {}
+
+    #[Route('api/import/pdf', name: 'api_import_pdf', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function importPdf(Request $request): JsonResponse
+    {
+        $file = $request->files->get('file');
+        $pathName = $file->getPathname();
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $fileType = finfo_file($finfo, $pathName);
+        $fileSize = $file->getSize();
+        $content = file_get_contents($pathName);
+        finfo_close($finfo);
+
+        if ($fileType != 'application/pdf') {
+            return $this->json(['message' => 'Invalid file type'], 422);
+        } elseif ($fileSize > 5242880) {
+            return $this->json(['message' => 'File size exceeds limit'], 413);
+        }
+        
+        // Security check
+        if (preg_match('/\/JavaScript|\/JS|\/AA|\/Launch|\/Action/i', $content)) { // Check for JavaScript/executable content (common PDF exploit vectors)
+            return $this->json(['message' => 'File security check failed'], 422);
+        } elseif (preg_match('/\/EmbeddedFile|\/FileAttachment/i', $content)) { // Check for embedded files
+            return $this->json(['message' => 'File security check failed'], 422);
+        }
+
+        try {
+            $importResult = $this->pdfImportService->parse($file);
+
+            if ($importResult->hasError()) {
+                return $this->json(['message' => $importResult->errorMessage], 422);
+            }
+        
+            $importResponse = new ImportResponse($importResult->cards);
+            return $this->json($importResponse);
+        } catch (Exception $e) {
+            return $this->json(['message' => 'Failed to process PDF: ' . $e->getMessage()], 500);
+        }
+    }
+}

--- a/src/Service/PdfImportService.php
+++ b/src/Service/PdfImportService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Service;
+
+use App\Dto\CardDto;
+use App\Service\ImportResult;
+use Smalot\PdfParser\Config;
+use Smalot\PdfParser\Parser;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class PdfImportService {
+
+    public function parse(UploadedFile $file): ImportResult
+    {
+        $cards = [];
+        $cardCount = 0;
+        $config = new Config();
+        $config->setDataTmFontInfoHasToBeIncluded(true);
+        $parser = new Parser([], $config);
+
+        try {
+            $pdf = $parser->parseFile($file->getPathname());
+            $text = $pdf->getText();
+
+            if (empty($text)) {
+                return new ImportResult([], 'No cards found');
+            }
+
+            $lines = array_map('trim', explode("\n", $text));
+            array_push($lines, "");
+            $sections = array_chunk($lines, 3);
+        } catch (Exception $e) {
+            return new ImportResult([], 'Failed to process PDF: ' . $e->getMessage());
+        }
+
+        foreach ($sections as $section) {
+            $cardCount++;
+
+            if (empty($section[0]) || empty($section[1])) {
+                return new ImportResult([], 'Missing front or back for Card '.$cardCount);
+            } elseif ($section[2]) {
+                return new ImportResult([], 'There must be a line break between each card');
+            }
+
+            $cardDto = new CardDto();
+            $cardDto->front = $section[0];
+            $cardDto->back = $section[1];
+            $cards[] = $cardDto;
+        }
+
+        $importResult = new ImportResult($cards);
+
+        return $importResult;
+    }
+}


### PR DESCRIPTION
Cette PR met en place l'importation de fichiers .pdf pour le contenu d'un deck. 
L'utilisateur dispose d'un fichier .pdf structuré de la manière suivante : 

```
Qu’est-ce que π ?
π est le rapport circonférence / diamètre.

Loi de Newton
F = m × a
```

 Ce fichier est envoyé dans <code>POST api/import/pdf</code> qui le lit et renvoie le résultat suivant :
```
{
   "cards": [
      {
         "front": "Qu’est-ce que π ?", 
         "back": "π est le rapport circonférence / diamètre."
      },
      { 
         "front": "Loi de Newton",
         "back": "F = m × a"
      }
   ],
   "cardCount": 2
}
```