### PR TITLE
feature: deck rating, route and subscriber

### DIFF
--- a/src/Controller/RateDeckController.php
+++ b/src/Controller/RateDeckController.php
@@ -75,4 +75,30 @@ class RateDeckController extends AbstractController
                 return $this->json(['error' => 'Method not allowed'], 405);
         }
     }
+
+    #[Route('/api/decks/{id}/rate', name: 'api_get_user_deck_rating', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function getUserRating(
+        string                 $id,
+        EntityManagerInterface $entityManager
+    ): JsonResponse
+    {
+        $deck = $entityManager->getRepository(Deck::class)->find($id);
+
+        if (!$deck) {
+            return $this->json(['error' => 'Deck not found'], 404);
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $deckRating = $entityManager->getRepository(DeckRating::class)
+            ->findOneBy(['deck' => $deck, 'rater' => $user]);
+
+        if (!$deckRating) {
+            return $this->json(['rating' => null], 200);
+        }
+
+        return $this->json(['rating' => $deckRating->getRating()], 200);
+    }
 }

--- a/src/Controller/RateDeckController.php
+++ b/src/Controller/RateDeckController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Deck;
+use App\Entity\DeckRating;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class RateDeckController extends AbstractController
+{
+    #[Route('/api/decks/{id}/rate', name: 'api_rate_deck', methods: ['POST', 'PUT', 'DELETE'])]
+    #[IsGranted('ROLE_USER')]
+    public function rateDeck(
+        string                 $id,
+        Request                $request,
+        EntityManagerInterface $entityManager
+    ): JsonResponse
+    {
+        $deck = $entityManager->getRepository(Deck::class)->find($id);
+
+        if (!$deck) {
+            return $this->json(['error' => 'Deck not found'], 404);
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+        $method = $request->getMethod();
+
+        // Find existing rating
+        $deckRating = $entityManager->getRepository(DeckRating::class)
+            ->findOneBy(['deck' => $deck, 'rater' => $user]);
+
+        switch ($method) {
+            case 'POST':
+            case 'PUT':
+                $data = json_decode($request->getContent(), true);
+                $ratingValue = $data['rating'] ?? null;
+
+                if ($ratingValue === null || $ratingValue < 1 || $ratingValue > 5) {
+                    return $this->json(['error' => 'Rating must be between 1 and 5'], 400);
+                }
+
+                if (!$deckRating) {
+                    $deckRating = new DeckRating();
+                    $deckRating->setDeck($deck);
+                    $deckRating->setRater($user);
+                }
+
+                $deckRating->setRating($ratingValue);
+                $entityManager->persist($deckRating);
+                $entityManager->flush();
+
+                return $this->json([
+                    'message' => 'Rating saved successfully',
+                    'rating' => $ratingValue
+                ], 201);
+
+            case 'DELETE':
+                if (!$deckRating) {
+                    return $this->json(['error' => 'No rating found to delete'], 404);
+                }
+
+                $entityManager->remove($deckRating);
+                $entityManager->flush();
+
+                return $this->json(['message' => 'Rating deleted successfully'], 200);
+
+            default:
+                return $this->json(['error' => 'Method not allowed'], 405);
+        }
+    }
+}

--- a/src/EventSubscriber/DeckRatingSubscriber.php
+++ b/src/EventSubscriber/DeckRatingSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Deck;
+use App\Entity\DeckRating;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostRemoveEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+
+#[AsDoctrineListener(event: 'postUpdate')]
+#[AsDoctrineListener(event: 'postPersist')]
+#[AsDoctrineListener(event: 'postRemove')]
+readonly class DeckRatingSubscriber
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager
+    )
+    {
+    }
+
+    public function postPersist(PostPersistEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof DeckRating) {
+            $this->updateDeckRatingStats($entity->getDeck());
+        }
+    }
+
+    private function updateDeckRatingStats(Deck $deck): void
+    {
+        $ratings = $this->entityManager->getRepository(DeckRating::class)
+            ->findBy(['deck' => $deck]);
+
+        $ratingCount = count($ratings);
+        $ratingAvg = 0.00;
+
+        if ($ratingCount > 0) {
+            $totalRating = array_sum(array_map(fn($rating) => $rating->getRating(), $ratings));
+            $ratingAvg = round($totalRating / $ratingCount, 2);
+        }
+
+        $deck->setRatingCount($ratingCount);
+        $deck->setRatingAvg($ratingAvg);
+
+        $this->entityManager->persist($deck);
+        $this->entityManager->flush();
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof DeckRating) {
+            $this->updateDeckRatingStats($entity->getDeck());
+        }
+    }
+
+    public function postRemove(PostRemoveEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if ($entity instanceof DeckRating) {
+            $this->updateDeckRatingStats($entity->getDeck());
+        }
+    }
+}


### PR DESCRIPTION
Cette PR ajoute une route concernant les notes des decks: 

- `/api/decks/{id}/rate` pour modifier la note d'un deck (pour l'utilisateur connecté) si ['POST', 'PUT', 'DELETE']
- Récupération de la note si ['GET']

De plus l'EventSubscriber `DeckRatingSubscriber` a été ajouté pour gérer les ratings côté `Deck` entity.