### PR TITLE
feature: audio review and matching text route

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -47,8 +47,9 @@ security:
         - { path: ^/api/register, roles: PUBLIC_ACCESS }
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api/ping, roles: PUBLIC_ACCESS }
-        - { path: ^/api, roles: PUBLIC_ACCESS }
+        - { path: ^/api/review/match, roles: ROLE_USER }
         - { path: ^/api/decks?mine=1, roles: ROLE_USER }
+        - { path: ^/api, roles: PUBLIC_ACCESS }
         - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
         - { path: ^/api/import, roles: ROLE_USER }
         # - { path: ^/admin, roles: ROLE_ADMIN }

--- a/src/Controller/TextMatchController.php
+++ b/src/Controller/TextMatchController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\TextSimiliarityService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+class TextMatchController extends AbstractController
+{
+    public function __construct(
+        private TextSimiliarityService $textSimiliarityService
+    ) {}
+
+    #[Route('/api/review/match', name: 'api_review_match', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function reviewMatch(Request $request): JsonResponse
+    {
+        $payload = $request->getPayload();
+        $expected = $payload->get('expected');
+        $spoken = $payload->get('spoken');
+
+        if (!$expected) {
+            return new JsonResponse(['error' => 'Expected text not found'], 422);
+        } elseif (!$spoken) {
+            return new JsonResponse(['error' => 'Spoken text not found'], 422);
+        }
+
+        if (mb_strlen($expected) > 1000) {
+            return new JsonResponse(['error' => 'Expected text too long'], 422);
+        } elseif (mb_strlen($spoken) > 1000) {
+            return new JsonResponse(['error' => 'Spoken text too long'], 422);
+        }
+
+        $match = $this->textSimiliarityService->ratio($expected, $spoken);
+
+        return $this->json(['match' => $match]);
+    }
+}

--- a/src/Service/ImportResponse.php
+++ b/src/Service/ImportResponse.php
@@ -8,6 +8,7 @@ use App\Controller\ImportCsvController;
 use App\Controller\ImportDocxController;
 use App\Controller\ImportJsonController;
 use App\Controller\ImportMarkdownController;
+use App\Controller\ImportPdfController;
 use App\Controller\ImportTxtController;
 use App\Controller\ImportXlsxController;
 use App\Dto\CardDto;
@@ -56,6 +57,13 @@ use Symfony\Component\Serializer\Annotation\Groups;
             inputFormats: ['multipart' => ['multipart/form-data']],
             output: ImportResponse::class,
             name: 'import_xlsx'
+        ),
+        new Post(
+            uriTemplate: '/import/pdf',
+            controller: ImportPdfController::class,
+            inputFormats: ['multipart' => ['multipart/form-data']],
+            output: ImportResponse::class,
+            name: 'import_pdf'
         )
     ],
     normalizationContext: ['groups' => ['import:read']]

--- a/src/Service/TextSimiliarityService.php
+++ b/src/Service/TextSimiliarityService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Service;
+
+final class TextSimiliarityService
+{
+    public function ratio(string $a, string $b): float
+    {
+        $normalize = fn(string $s) => trim(
+            preg_replace('/[^\p{L}\d]+/u', '', iconv('UTF-8', 'ASCII//TRANSLIT', mb_strtolower($s)))
+        );
+
+        similar_text($normalize($a), $normalize($b), $percent);
+
+        return round($percent, 1);
+    }
+}


### PR DESCRIPTION
Cette PR met en place l'implémentation de la révision audio et la comparaison de texte.

Un utilisateur dicte une phrase qui sera retranscrit via Web Speech ou mobile et comparé avec le recto ou le verso d'une carte dans <code>POST api/review/match</code>. Un pourcentage de comparaison est ensuite renvoyé par le backend.