### PR TITLE
feature: home feed

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -26,6 +26,9 @@ doctrine:
                 alias: App
         controller_resolver:
             auto_mapping: false
+        dql:
+            numeric_functions:
+                RANDOM: App\Doctrine\DBAL\FunctionNode\Random
 
 when@test:
     doctrine:

--- a/src/Controller/HomeDeckFeedController.php
+++ b/src/Controller/HomeDeckFeedController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\DeckRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\Cache;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HomeDeckFeedController extends AbstractController
+{
+    #[Route('/api/home/decks', name:'api_home_decks', methods: ['GET'])]
+    #[Cache(public: true, maxage: 60)]
+    public function __invoke(Request $request, DeckRepository $deckRepository): JsonResponse
+    {
+        $payload = $request->getPayload();
+        $size = $payload->get('size', 12);
+
+        if ($size < 1 || $size > 24) {
+            return $this->json(['message' => 'Size must be between 1 and 24'], 422);
+        }
+
+        $top = $payload->get('top', 6);
+
+        if ($top < 0 || $top > $size) {
+            return $this->json(['message' => 'Top must be between 0 and '.$size], 422);
+        }
+
+        $best = $deckRepository->findTopRated($top);
+        $ids = array_column($best, 'id');
+        $random = $deckRepository->findRandomPublicPublished($size - count($best), $ids);
+
+        $mix = array_merge($best, $random);
+        shuffle($mix);
+
+        return $this->json(['decks' => $mix], 200, []);
+    }
+}

--- a/src/Controller/HomeDeckFeedController.php
+++ b/src/Controller/HomeDeckFeedController.php
@@ -36,6 +36,6 @@ final class HomeDeckFeedController extends AbstractController
         $mix = array_merge($best, $random);
         shuffle($mix);
 
-        return $this->json(['decks' => $mix], 200, []);
+        return $this->json(['decks' => $mix], 200, [], ['groups' => ['home:list']]);
     }
 }

--- a/src/Controller/TextMatchController.php
+++ b/src/Controller/TextMatchController.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class TextMatchController extends AbstractController
 {
@@ -24,15 +25,15 @@ class TextMatchController extends AbstractController
         $spoken = $payload->get('spoken');
 
         if (!$expected) {
-            return new JsonResponse(['error' => 'Expected text not found'], 422);
+            return $this->json(['message' => 'Expected text not found'], 422);
         } elseif (!$spoken) {
-            return new JsonResponse(['error' => 'Spoken text not found'], 422);
+            return $this->json(['message' => 'Spoken text not found'], 422);
         }
 
         if (mb_strlen($expected) > 1000) {
-            return new JsonResponse(['error' => 'Expected text too long'], 422);
+            return $this->json(['message' => 'Expected text too long'], 422);
         } elseif (mb_strlen($spoken) > 1000) {
-            return new JsonResponse(['error' => 'Spoken text too long'], 422);
+            return $this->json(['message' => 'Spoken text too long'], 422);
         }
 
         $match = $this->textSimiliarityService->ratio($expected, $spoken);

--- a/src/Doctrine/DBAL/FunctionNode/Random.php
+++ b/src/Doctrine/DBAL/FunctionNode/Random.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Doctrine\DBAL\FunctionNode;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\TokenType;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+final class Random extends FunctionNode
+{
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        return 'RANDOM()';
+    }
+}

--- a/src/Entity/Deck.php
+++ b/src/Entity/Deck.php
@@ -31,7 +31,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[ApiFilter(MineDecksFilter::class, properties: ['mine'])]
 #[ApiResource(
     operations: [
-        new Get(normalizationContext: ['groups' => ['deck:read', 'deck:item', 'deck:list', 'uuid']]),
+        new Get(normalizationContext: ['groups' => ['deck:read', 'deck:item', 'deck:list', 'uuid', 'home:list']]),
         new Get(
             uriTemplate: '/decks/{id}/stats',
             controller: DeckStatsController::class,
@@ -67,7 +67,7 @@ class Deck
     private ?User $owner = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['deck:read', 'deck:item', 'deck:list', 'queue:item', 'deck:update'])]
+    #[Groups(['deck:read', 'deck:item', 'deck:list', 'queue:item', 'deck:update', 'home:list'])]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
@@ -75,7 +75,7 @@ class Deck
     private ?string $description = null;
 
     #[ORM\Column(nullable: true, enumType: CountryCodeAlpha2::class)]
-    #[Groups(['deck:read', 'deck:item', 'deck:update'])]
+    #[Groups(['deck:read', 'deck:item', 'deck:update', 'home:list'])]
     private ?CountryCodeAlpha2 $language = null;
 
     #[ORM\Column(enumType: DeckVisibility::class)]
@@ -84,7 +84,7 @@ class Deck
     private ?DeckVisibility $visibility = DeckVisibility::UNLISTED;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 3, scale: 2)]
-    #[Groups(['deck:read', 'deck:item'])]
+    #[Groups(['deck:read', 'deck:item', 'home:list'])]
     private float $rating_avg = 0.00;
 
     #[ORM\Column]
@@ -92,7 +92,7 @@ class Deck
     private int $rating_count = 0;
 
     #[ORM\Column]
-    #[Groups(['deck:read', 'deck:item', 'deck:list', 'queue:item'])]
+    #[Groups(['deck:read', 'deck:item', 'deck:list', 'queue:item', 'home:list'])]
     private int $card_count = 0;
 
     #[ORM\Column(enumType: DeckStatus::class)]

--- a/src/Entity/Traits/UuidTrait.php
+++ b/src/Entity/Traits/UuidTrait.php
@@ -14,7 +14,7 @@ trait UuidTrait
     #[ORM\Column(type: UuidType::NAME, unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    #[Groups(['uuid', 'deck:list'])]
+    #[Groups(['uuid', 'deck:list', 'home:list'])]
     private ?Uuid $id = null;
 
     public function getId(): ?Uuid

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -32,7 +32,7 @@ class DeckRepository extends ServiceEntityRepository
             ->addOrderBy('d.rating_count', 'DESC')
             ->setMaxResults($limit)
             ->getQuery()
-            ->getArrayResult()
+            ->getResult()
         ;
     }
 
@@ -56,7 +56,7 @@ class DeckRepository extends ServiceEntityRepository
         return $queryBuilder->orderBy('RANDOM()')
             ->setMaxResults($limit)
             ->getQuery()
-            ->getArrayResult()
+            ->getResult()
         ;
     }
 

--- a/src/Repository/DeckRepository.php
+++ b/src/Repository/DeckRepository.php
@@ -4,6 +4,8 @@ namespace App\Repository;
 
 use App\Entity\Deck;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\Parameter;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,6 +16,48 @@ class DeckRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Deck::class);
+    }
+
+    public function findTopRated(int $limit): array
+    {
+        return $this->createQueryBuilder('d')
+            ->where('d.visibility = :pub')
+            ->andWhere('d.status = :publi')
+            ->andWhere('d.rating_count >= 5')
+            ->setParameters(new ArrayCollection([
+                new Parameter('pub', 'public'), 
+                new Parameter('publi', 'published')
+            ]))
+            ->orderBy('d.rating_avg', 'DESC')
+            ->addOrderBy('d.rating_count', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getArrayResult()
+        ;
+    }
+
+    public function findRandomPublicPublished(int $limit, array $excludeIds = []): array
+    {
+        $queryBuilder = $this->createQueryBuilder('d')
+            ->where('d.visibility = :pub')
+            ->andWhere('d.status = :publi')
+            ->setParameters(new ArrayCollection([
+                new Parameter('pub', 'public'), 
+                new Parameter('publi', 'published')
+            ]))
+        ;
+
+        if ($excludeIds) {
+            $queryBuilder->andWhere($queryBuilder->expr()->notIn('d.id', ':excl'))
+                ->setParameter('excl', $excludeIds)
+            ;
+        }
+
+        return $queryBuilder->orderBy('RANDOM()')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getArrayResult()
+        ;
     }
 
     //    /**


### PR DESCRIPTION
Cette PR met en place l'implémentation de l'home feed.

Sur la page d'accueil, l'utilisateur choisit une taille <code>size</code> (12 par défaut) et le nombre de meilleurs cartes à afficher <code>top</code> (6 par défaut). Ces données seront envoyées dans <code>GET api/home/decks</code> qui renvoiera une liste de decks composé de <code>top</code> des meilleurs decks et de decks aléatoires et dont l'ordre sera différent à chaque appel.