### PR TITLE
feature: user preferences

### DIFF
--- a/migrations/Version20250922190347.php
+++ b/migrations/Version20250922190347.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250922190347 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE user_preference (id SERIAL NOT NULL, owner_id UUID NOT NULL, theme VARCHAR(255) DEFAULT NULL, language VARCHAR(255) DEFAULT NULL, daily_reminder TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, cards_per_session SMALLINT NOT NULL, notif_on_level_up BOOLEAN NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_FA0E76BF7E3C61F9 ON user_preference (owner_id)');
+        $this->addSql('COMMENT ON COLUMN user_preference.owner_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN user_preference.daily_reminder IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE user_preference ADD CONSTRAINT FK_FA0E76BF7E3C61F9 FOREIGN KEY (owner_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE user_preference DROP CONSTRAINT FK_FA0E76BF7E3C61F9');
+        $this->addSql('DROP TABLE user_preference');
+    }
+}

--- a/src/Controller/UserPreferenceController.php
+++ b/src/Controller/UserPreferenceController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Entity\UserPreference;
+use App\Enum\CountryCodeAlpha2;
+use App\Enum\Theme;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class UserPreferenceController extends AbstractController
+{
+    #[Route('/api/me/preferences', name: 'api_me_preferences', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function getPreferences(): JsonResponse
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $preferences = $user->getUserPreference();
+
+        if (!$preferences) {
+            return $this->json(['message' => 'Preferences not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($preferences, Response::HTTP_OK, [], ['groups' => ['pref:read']]);
+    }
+
+    #[Route('/api/me/preferences', name: 'api_me_preferences_update', methods: ['PUT'])]
+    #[IsGranted('ROLE_USER')]
+    public function updatePreferences(EntityManagerInterface $entityManager, Request $request): JsonResponse
+    {
+        $user = $this->getUser();
+        $preferences = $user->getUserPreference();
+        $payload = $request->getPayload();
+
+        if (!$user instanceof User) {
+            return $this->json(['message' => 'Not authenticated'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (!$preferences) {
+            $preferences = new UserPreference();
+            $preferences->setOwner($user);
+        }
+
+        $theme = $payload->get('theme');
+        $language = $payload->get('language');
+        $cardsPerSession = $payload->get('cardsPerSession');
+
+        if ($theme && !in_array($theme, Theme::cases())) {
+            return $this->json(['message' => 'Invalid theme'], 422);
+        } elseif ($language && !in_array($language, CountryCodeAlpha2::cases())) {
+            return $this->json(['message' => 'Invalid language'], 422);
+        } elseif ($cardsPerSession && ($cardsPerSession < 5 || $cardsPerSession > 100)) {
+            return $this->json(['message' => 'Cards per session must be between 5 and 100'], 422);
+        }
+
+        if ($theme) {
+            $preferences->setTheme(Theme::from($theme));
+        }
+
+        if ($language) {
+            $preferences->setLanguage(CountryCodeAlpha2::from($language));
+        }
+
+        if ($cardsPerSession) {
+            $preferences->setCardsPerSession($cardsPerSession);
+        }
+
+        $entityManager->persist($preferences);
+        $entityManager->flush();
+
+        return $this->json(['message' => 'Preferences updated successfully'], 200);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -138,6 +138,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: ReviewProgress::class, mappedBy: 'reviewer', orphanRemoval: true)]
     private Collection $reviewProgress;
 
+    #[ORM\OneToOne(mappedBy: 'owner', cascade: ['persist', 'remove'])]
+    private ?UserPreference $userPreference = null;
+
     public function __construct()
     {
         $this->userBadges = new ArrayCollection();
@@ -668,6 +671,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
                 $reviewProgress->setReviewer(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getUserPreference(): ?UserPreference
+    {
+        return $this->userPreference;
+    }
+
+    public function setUserPreference(UserPreference $userPreference): static
+    {
+        // set the owning side of the relation if necessary
+        if ($userPreference->getOwner() !== $this) {
+            $userPreference->setOwner($this);
+        }
+
+        $this->userPreference = $userPreference;
 
         return $this;
     }

--- a/src/Entity/UserPreference.php
+++ b/src/Entity/UserPreference.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use App\Enum\CountryCodeAlpha2;
+use App\Enum\Theme;
+use App\Repository\UserPreferenceRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: UserPreferenceRepository::class)]
+#[ApiResource]
+class UserPreference
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\OneToOne(inversedBy: 'userPreference', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $owner = null;
+
+    #[ORM\Column(nullable:true, enumType: Theme::class)]
+    private ?Theme $theme = Theme::AUTO;
+
+    #[ORM\Column(nullable: true, enumType: CountryCodeAlpha2::class)]
+    private ?CountryCodeAlpha2 $language = CountryCodeAlpha2::France;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $dailyReminder = null;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private ?int $cardsPerSession = 20;
+
+    #[ORM\Column]
+    private ?bool $notifOnLevelUp = true;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(User $owner): static
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getTheme(): ?Theme
+    {
+        return $this->theme;
+    }
+
+    public function setTheme(?Theme $theme): static
+    {
+        $this->theme = $theme;
+
+        return $this;
+    }
+
+    public function getLanguage(): ?CountryCodeAlpha2
+    {
+        return $this->language;
+    }
+
+    public function setLanguage(?CountryCodeAlpha2 $language): static
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    public function getDailyReminder(): ?\DateTime
+    {
+        return $this->dailyReminder;
+    }
+
+    public function setDailyReminder(?\DateTime $dailyReminder): static
+    {
+        $this->dailyReminder = $dailyReminder;
+
+        return $this;
+    }
+
+    public function getCardsPerSession(): ?int
+    {
+        return $this->cardsPerSession;
+    }
+
+    public function setCardsPerSession(int $cardsPerSession): static
+    {
+        $this->cardsPerSession = $cardsPerSession;
+
+        return $this;
+    }
+
+    public function isNotifOnLevelUp(): ?bool
+    {
+        return $this->notifOnLevelUp;
+    }
+
+    public function setNotifOnLevelUp(bool $notifOnLevelUp): static
+    {
+        $this->notifOnLevelUp = $notifOnLevelUp;
+
+        return $this;
+    }
+}

--- a/src/Entity/UserPreference.php
+++ b/src/Entity/UserPreference.php
@@ -3,14 +3,30 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
 use App\Enum\CountryCodeAlpha2;
 use App\Enum\Theme;
 use App\Repository\UserPreferenceRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: UserPreferenceRepository::class)]
-#[ApiResource]
+#[ApiResource(
+    operations: [
+      new Get(
+        uriTemplate: 'api/me/preferences',
+        security: "is_granted('ROLE_USER') && object.getUser() == user",
+        normalizationContext: ['groups' => ['pref:read']]
+      ),
+      new Put(
+        uriTemplate: 'api/me/preferences',
+        security: "is_granted('ROLE_USER') && object.getUser() == user",
+        denormalizationContext: ['groups' => ['pref:write']]
+      ),
+    ]
+)]
 class UserPreference
 {
     #[ORM\Id]
@@ -23,18 +39,23 @@ class UserPreference
     private ?User $owner = null;
 
     #[ORM\Column(nullable:true, enumType: Theme::class)]
+    #[Groups(['pref:read', 'pref:write'])]
     private ?Theme $theme = Theme::AUTO;
 
     #[ORM\Column(nullable: true, enumType: CountryCodeAlpha2::class)]
+    #[Groups(['pref:read', 'pref:write'])]
     private ?CountryCodeAlpha2 $language = CountryCodeAlpha2::France;
 
     #[ORM\Column(nullable: true)]
+    #[Groups(['pref:read', 'pref:write'])]
     private ?\DateTimeImmutable $dailyReminder = null;
 
     #[ORM\Column(type: Types::SMALLINT)]
+    #[Groups(['pref:read', 'pref:write'])]
     private ?int $cardsPerSession = 20;
 
     #[ORM\Column]
+    #[Groups(['pref:read', 'pref:write'])]
     private ?bool $notifOnLevelUp = true;
 
     public function getId(): ?int
@@ -78,12 +99,12 @@ class UserPreference
         return $this;
     }
 
-    public function getDailyReminder(): ?\DateTime
+    public function getDailyReminder(): ?\DateTimeImmutable
     {
         return $this->dailyReminder;
     }
 
-    public function setDailyReminder(?\DateTime $dailyReminder): static
+    public function setDailyReminder(?\DateTimeImmutable $dailyReminder): static
     {
         $this->dailyReminder = $dailyReminder;
 

--- a/src/Enum/Theme.php
+++ b/src/Enum/Theme.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum Theme: string
+{
+    case LIGHT = 'light';
+    case DARK = 'dark';
+    case AUTO = 'auto';
+}

--- a/src/Repository/UserPreferenceRepository.php
+++ b/src/Repository/UserPreferenceRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\UserPreference;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<UserPreference>
+ */
+class UserPreferenceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserPreference::class);
+    }
+
+    //    /**
+    //     * @return UserPreference[] Returns an array of UserPreference objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('u')
+    //            ->andWhere('u.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('u.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?UserPreference
+    //    {
+    //        return $this->createQueryBuilder('u')
+    //            ->andWhere('u.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}


### PR DESCRIPTION
Cette PR met en place les préférences personnelles d’un utilisateur.
Les préférences sont constituées d'un thème, d'un langage, d'un rappel individuel, du nombre de cartes par session et d'une notification pour l'augmention de niveau.

Les préférences sont accessibles / modifiables via une seule route :

```
GET  /api/me/preferences
PUT  /api/me/preferences      (body JSON)
```